### PR TITLE
Introduce JUCE-based C++ audio skeleton

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 3.14)
+project(DIY_AV_CPP)
+
+add_subdirectory(src/cpp_audio)

--- a/README_Audio.md
+++ b/README_Audio.md
@@ -72,3 +72,6 @@ duration adapts to the step length:
 
 This behaviour ensures that very long steps do not delay the preview yet short
 steps can still be heard in full.
+
+## C++ Port
+A minimal C++ implementation using JUCE lives in `src/cpp_audio`. Build it with CMake and ensure JUCE is available on your system.

--- a/src/cpp_audio/AudioUtils.cpp
+++ b/src/cpp_audio/AudioUtils.cpp
@@ -1,0 +1,43 @@
+#include "AudioUtils.h"
+#include <cmath>
+
+juce::AudioBuffer<float> generateSine(double freq, double amp, double duration, double sampleRate)
+{
+    auto n = static_cast<int>(duration * sampleRate);
+    juce::AudioBuffer<float> buffer(2, n);
+    for (int ch = 0; ch < 2; ++ch)
+    {
+        auto* data = buffer.getWritePointer(ch);
+        double phase = 0.0;
+        double increment = juce::MathConstants<double>::twoPi * freq / sampleRate;
+        for (int i = 0; i < n; ++i)
+        {
+            data[i] = static_cast<float>(std::sin(phase) * amp);
+            phase += increment;
+        }
+    }
+    return buffer;
+}
+
+juce::AudioBuffer<float> crossfade(const juce::AudioBuffer<float>& a, const juce::AudioBuffer<float>& b, double duration, double sampleRate, juce::String curve)
+{
+    int n = static_cast<int>(duration * sampleRate);
+    n = std::min({ n, a.getNumSamples(), b.getNumSamples() });
+    juce::AudioBuffer<float> result(2, n);
+
+    for (int ch = 0; ch < 2; ++ch)
+    {
+        const float* pa = a.getReadPointer(ch);
+        const float* pb = b.getReadPointer(ch);
+        float* pr = result.getWritePointer(ch);
+        for (int i = 0; i < n; ++i)
+        {
+            double alpha = static_cast<double>(i) / static_cast<double>(n);
+            if (curve == "equal_power")
+                alpha = std::sin(alpha * juce::MathConstants<double>::halfPi);
+            pr[i] = pa[i] * (1.0 - alpha) + pb[i] * alpha;
+        }
+    }
+    return result;
+}
+

--- a/src/cpp_audio/AudioUtils.h
+++ b/src/cpp_audio/AudioUtils.h
@@ -1,0 +1,5 @@
+#pragma once
+#include <juce_audio_basics/juce_audio_basics.h>
+
+juce::AudioBuffer<float> generateSine(double freq, double amp, double duration, double sampleRate);
+juce::AudioBuffer<float> crossfade(const juce::AudioBuffer<float>& a, const juce::AudioBuffer<float>& b, double duration, double sampleRate, juce::String curve);

--- a/src/cpp_audio/CMakeLists.txt
+++ b/src/cpp_audio/CMakeLists.txt
@@ -1,0 +1,35 @@
+cmake_minimum_required(VERSION 3.14)
+
+project(DIY_AV_Audio_CPP)
+
+# Look for JUCE via find_package. The user must set JUCE_ROOT or add
+# the JUCE install prefix to CMAKE_PREFIX_PATH.
+
+find_package(JUCE CONFIG REQUIRED)
+
+# Enable JUCE modules required by the conversion plan
+juce_add_console_app(diy_av_audio_cpp
+    PRODUCT_NAME "DIY AV Audio CPP"
+    BUNDLE_ID com.example.diyavcpp
+    VERSION 0.1
+    SOURCES
+        main.cpp
+        Track.h
+        Track.cpp
+        SynthFunctions.h
+        SynthFunctions.cpp
+        AudioUtils.h
+        AudioUtils.cpp
+)
+
+# Link necessary JUCE modules
+
+juce_generate_juce_header(diy_av_audio_cpp)
+
+target_link_libraries(diy_av_audio_cpp
+    PRIVATE
+        juce::juce_audio_utils
+        juce::juce_dsp
+        juce::juce_audio_formats
+)
+

--- a/src/cpp_audio/SynthFunctions.cpp
+++ b/src/cpp_audio/SynthFunctions.cpp
@@ -1,0 +1,55 @@
+#include "SynthFunctions.h"
+#include "AudioUtils.h"
+#include <cmath>
+
+juce::AudioBuffer<float> binauralBeat(double duration, double sampleRate, const juce::NamedValueSet& params)
+{
+    double ampL = params.getWithDefault("ampL", 0.5);
+    double ampR = params.getWithDefault("ampR", 0.5);
+    double baseFreq = params.getWithDefault("baseFreq", 200.0);
+    double beatFreq = params.getWithDefault("beatFreq", 4.0);
+
+    auto left = generateSine(baseFreq - beatFreq/2.0, ampL, duration, sampleRate);
+    auto right = generateSine(baseFreq + beatFreq/2.0, ampR, duration, sampleRate);
+
+    juce::AudioBuffer<float> result(2, left.getNumSamples());
+    result.copyFrom(0, 0, left, 0, 0, left.getNumSamples());
+    result.copyFrom(1, 0, right, 1, 0, right.getNumSamples());
+    return result;
+}
+
+juce::AudioBuffer<float> isochronicTone(double duration, double sampleRate, const juce::NamedValueSet& params)
+{
+    double amp = params.getWithDefault("amp", 0.5);
+    double baseFreq = params.getWithDefault("baseFreq", 200.0);
+    double beatFreq = params.getWithDefault("beatFreq", 4.0);
+    double rampPercent = params.getWithDefault("rampPercent", 0.2);
+    double gapPercent = params.getWithDefault("gapPercent", 0.15);
+
+    int totalSamples = static_cast<int>(duration * sampleRate);
+    juce::AudioBuffer<float> buffer(2, totalSamples);
+
+    double phase = 0.0;
+    double dt = 1.0 / sampleRate;
+    for (int i = 0; i < totalSamples; ++i)
+    {
+        double cycle = 1.0 / beatFreq;
+        double tInCycle = std::fmod(i * dt, cycle);
+        double env = 1.0;
+        double onTime = cycle * (1.0 - gapPercent);
+        double rampTime = onTime * rampPercent;
+        if (tInCycle > onTime)
+            env = 0.0;
+        else if (tInCycle < rampTime)
+            env = tInCycle / rampTime;
+        else if (tInCycle > (onTime - rampTime))
+            env = (onTime - tInCycle) / rampTime;
+
+        float sample = static_cast<float>(std::sin(phase) * amp * env);
+        buffer.setSample(0, i, sample);
+        buffer.setSample(1, i, sample);
+        phase += juce::MathConstants<double>::twoPi * baseFreq * dt;
+    }
+    return buffer;
+}
+

--- a/src/cpp_audio/SynthFunctions.h
+++ b/src/cpp_audio/SynthFunctions.h
@@ -1,0 +1,7 @@
+#pragma once
+#include <juce_audio_basics/juce_audio_basics.h>
+#include "Track.h"
+
+juce::AudioBuffer<float> binauralBeat(double duration, double sampleRate, const juce::NamedValueSet& params);
+juce::AudioBuffer<float> isochronicTone(double duration, double sampleRate, const juce::NamedValueSet& params);
+

--- a/src/cpp_audio/Track.cpp
+++ b/src/cpp_audio/Track.cpp
@@ -1,0 +1,65 @@
+#include "Track.h"
+#include <juce_data_structures/juce_data_structures.h>
+#include <juce_audio_formats/juce_audio_formats.h>
+
+Track loadTrackFromJson(const juce::File& file)
+{
+    Track track;
+    auto stream = file.createInputStream();
+    if (!stream)
+        return track;
+
+    juce::var parsed = juce::JSON::parse(stream->readEntireStreamAsString());
+    if (auto* obj = parsed.getDynamicObject())
+    {
+        if (auto* gs = obj->getProperty("global_settings").getDynamicObject())
+        {
+            track.settings.sampleRate = gs->getProperty("sample_rate", 44100.0);
+            track.settings.crossfadeDuration = gs->getProperty("crossfade_duration", 1.0);
+            track.settings.crossfadeCurve = gs->getProperty("crossfade_curve").toString();
+        }
+
+        if (auto* stepsVar = obj->getProperty("steps").getArray())
+        {
+            for (const auto& s : *stepsVar)
+            {
+                Step step;
+                if (auto* sobj = s.getDynamicObject())
+                {
+                    step.durationSeconds = sobj->getProperty("duration", 0.0);
+                    if (auto* voicesVar = sobj->getProperty("voices").getArray())
+                    {
+                        for (const auto& v : *voicesVar)
+                        {
+                            Voice voice;
+                            if (auto* vobj = v.getDynamicObject())
+                            {
+                                voice.synthFunction = vobj->getProperty("synth_function_name").toString().toStdString();
+                                voice.isTransition = vobj->getProperty("is_transition", false);
+                                if (auto* paramsObj = vobj->getProperty("params").getDynamicObject())
+                                    voice.params = *paramsObj;
+                            }
+                            step.voices.push_back(std::move(voice));
+                        }
+                    }
+                }
+                track.steps.push_back(std::move(step));
+            }
+        }
+    }
+    return track;
+}
+
+bool writeWavFile(const juce::File& file, const juce::AudioBuffer<float>& buffer, double sampleRate)
+{
+    juce::WavAudioFormat format;
+    std::unique_ptr<juce::FileOutputStream> stream(file.createOutputStream());
+    if (!stream)
+        return false;
+    std::unique_ptr<juce::AudioFormatWriter> writer(format.createWriterFor(stream.get(), sampleRate, buffer.getNumChannels(), 16, {}, 0));
+    if (!writer)
+        return false;
+    stream.release();
+    return writer->writeFromAudioSampleBuffer(buffer, 0, buffer.getNumSamples());
+}
+

--- a/src/cpp_audio/Track.h
+++ b/src/cpp_audio/Track.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <juce_audio_basics/juce_audio_basics.h>
+#include <juce_core/juce_core.h>
+#include <vector>
+#include <string>
+
+struct Voice
+{
+    std::string synthFunction;
+    juce::NamedValueSet params;
+    bool isTransition { false };
+};
+
+struct Step
+{
+    double durationSeconds { 0.0 };
+    std::vector<Voice> voices;
+};
+
+struct GlobalSettings
+{
+    double sampleRate { 44100.0 };
+    double crossfadeDuration { 1.0 };
+    juce::String crossfadeCurve { "linear" };
+};
+
+struct Track
+{
+    GlobalSettings settings;
+    std::vector<Step> steps;
+};
+
+Track loadTrackFromJson(const juce::File& file);
+bool writeWavFile(const juce::File& file, const juce::AudioBuffer<float>& buffer, double sampleRate);
+

--- a/src/cpp_audio/main.cpp
+++ b/src/cpp_audio/main.cpp
@@ -1,0 +1,61 @@
+#include "Track.h"
+#include "SynthFunctions.h"
+#include "AudioUtils.h"
+#include <juce_core/juce_core.h>
+#include <juce_audio_formats/juce_audio_formats.h>
+#include <map>
+
+using SynthFunc = juce::AudioBuffer<float>(*)(double, double, const juce::NamedValueSet&);
+
+static std::map<juce::String, SynthFunc> synthMap {
+    { "binaural_beat", binauralBeat },
+    { "isochronic_tone", isochronicTone }
+};
+
+int main (int argc, char* argv[])
+{
+    juce::ConsoleApplication app (argc, argv);
+
+    if (argc < 3)
+    {
+        juce::Logger::writeToLog("Usage: diy_av_audio_cpp <input.json> <output.wav>");
+        return 1;
+    }
+
+    juce::File inFile(argv[1]);
+    juce::File outFile(argv[2]);
+    Track track = loadTrackFromJson(inFile);
+
+    double sampleRate = track.settings.sampleRate;
+    int totalSamples = 0;
+    for (const auto& step : track.steps)
+        totalSamples += static_cast<int>(step.durationSeconds * sampleRate);
+
+    juce::AudioBuffer<float> trackBuffer(2, totalSamples);
+    int pos = 0;
+
+    for (size_t i = 0; i < track.steps.size(); ++i)
+    {
+        const auto& step = track.steps[i];
+        juce::AudioBuffer<float> stepBuffer(2, static_cast<int>(step.durationSeconds * sampleRate));
+        stepBuffer.clear();
+        for (const auto& voice : step.voices)
+        {
+            auto it = synthMap.find(voice.synthFunction);
+            if (it != synthMap.end())
+            {
+                auto voiceBuf = it->second(step.durationSeconds, sampleRate, voice.params);
+                for (int ch = 0; ch < 2; ++ch)
+                    stepBuffer.addFrom(ch, 0, voiceBuf, ch, 0, voiceBuf.getNumSamples());
+            }
+        }
+
+        trackBuffer.copyFrom(0, pos, stepBuffer, 0, 0, stepBuffer.getNumSamples());
+        trackBuffer.copyFrom(1, pos, stepBuffer, 1, 0, stepBuffer.getNumSamples());
+        pos += stepBuffer.getNumSamples();
+    }
+
+    writeWavFile(outFile, trackBuffer, sampleRate);
+    return 0;
+}
+


### PR DESCRIPTION
## Summary
- add CMake build files for a JUCE project
- implement minimal C++ audio track reader and synth functions
- document the new `src/cpp_audio` folder in the audio README

## Testing
- `cmake --version`
- `cmake ..` *(fails: Could not find a package configuration file provided by "JUCE")*

------
https://chatgpt.com/codex/tasks/task_e_685b16b13d54832d905de09b27de3318