### PR TITLE
Refactor synth implementations

### DIFF
--- a/src/cpp_audio/AudioUtils.h
+++ b/src/cpp_audio/AudioUtils.h
@@ -1,5 +1,18 @@
 #pragma once
 #include <juce_audio_basics/juce_audio_basics.h>
+#include <utility>
+#include <vector>
 
 juce::AudioBuffer<float> generateSine(double freq, double amp, double duration, double sampleRate);
-juce::AudioBuffer<float> crossfade(const juce::AudioBuffer<float>& a, const juce::AudioBuffer<float>& b, double duration, double sampleRate, juce::String curve);
+juce::AudioBuffer<float> crossfade(const juce::AudioBuffer<float>& a,
+                                   const juce::AudioBuffer<float>& b,
+                                   double duration,
+                                   double sampleRate,
+                                   juce::String curve);
+
+std::pair<float, float> getPanGains(double pan);
+std::vector<double> calculateTransitionAlpha(double totalDuration,
+                                             double sampleRate,
+                                             double initialOffset = 0.0,
+                                             double postOffset = 0.0,
+                                             juce::String curve = "linear");

--- a/src/cpp_audio/CMakeLists.txt
+++ b/src/cpp_audio/CMakeLists.txt
@@ -2,12 +2,8 @@ cmake_minimum_required(VERSION 3.14)
 
 project(DIY_AV_Audio_CPP)
 
-# Look for JUCE via find_package. The user must set JUCE_ROOT or add
-# the JUCE install prefix to CMAKE_PREFIX_PATH.
-
 find_package(JUCE CONFIG REQUIRED)
 
-# Enable JUCE modules required by the conversion plan
 juce_add_console_app(diy_av_audio_cpp
     PRODUCT_NAME "DIY AV Audio CPP"
     BUNDLE_ID com.example.diyavcpp
@@ -17,12 +13,20 @@ juce_add_console_app(diy_av_audio_cpp
         Track.h
         Track.cpp
         SynthFunctions.h
-        SynthFunctions.cpp
+        synths/BinauralBeat.cpp
+        synths/IsochronicTone.cpp
+        synths/RhythmicWaveshaping.cpp
+        synths/StereoAMIndependent.cpp
+        synths/WaveShapeStereoAm.cpp
+        synths/MonauralBeatStereoAmps.cpp
+        synths/QamBeat.cpp
+        synths/HybridQamMonauralBeat.cpp
+        synths/SpatialAngleModulation.cpp
+        synths/NoiseFlanger.cpp
+        synths/Subliminals.cpp
         AudioUtils.h
         AudioUtils.cpp
 )
-
-# Link necessary JUCE modules
 
 juce_generate_juce_header(diy_av_audio_cpp)
 
@@ -32,4 +36,3 @@ target_link_libraries(diy_av_audio_cpp
         juce::juce_dsp
         juce::juce_audio_formats
 )
-

--- a/src/cpp_audio/SynthFunctions.h
+++ b/src/cpp_audio/SynthFunctions.h
@@ -3,5 +3,34 @@
 #include "Track.h"
 
 juce::AudioBuffer<float> binauralBeat(double duration, double sampleRate, const juce::NamedValueSet& params);
+juce::AudioBuffer<float> binauralBeatTransition(double duration, double sampleRate, const juce::NamedValueSet& params);
+
 juce::AudioBuffer<float> isochronicTone(double duration, double sampleRate, const juce::NamedValueSet& params);
 
+juce::AudioBuffer<float> rhythmicWaveshaping(double duration, double sampleRate, const juce::NamedValueSet& params);
+juce::AudioBuffer<float> rhythmicWaveshapingTransition(double duration, double sampleRate, const juce::NamedValueSet& params);
+
+juce::AudioBuffer<float> stereoAMIndependent(double duration, double sampleRate, const juce::NamedValueSet& params);
+juce::AudioBuffer<float> stereoAMIndependentTransition(double duration, double sampleRate, const juce::NamedValueSet& params);
+
+juce::AudioBuffer<float> waveShapeStereoAm(double duration, double sampleRate, const juce::NamedValueSet& params);
+juce::AudioBuffer<float> waveShapeStereoAmTransition(double duration, double sampleRate, const juce::NamedValueSet& params);
+
+juce::AudioBuffer<float> monauralBeatStereoAmps(double duration, double sampleRate, const juce::NamedValueSet& params);
+juce::AudioBuffer<float> monauralBeatStereoAmpsTransition(double duration, double sampleRate, const juce::NamedValueSet& params);
+
+juce::AudioBuffer<float> qamBeat(double duration, double sampleRate, const juce::NamedValueSet& params);
+juce::AudioBuffer<float> qamBeatTransition(double duration, double sampleRate, const juce::NamedValueSet& params);
+
+juce::AudioBuffer<float> hybridQamMonauralBeat(double duration, double sampleRate, const juce::NamedValueSet& params);
+juce::AudioBuffer<float> hybridQamMonauralBeatTransition(double duration, double sampleRate, const juce::NamedValueSet& params);
+
+juce::AudioBuffer<float> spatialAngleModulation(double duration, double sampleRate, const juce::NamedValueSet& params);
+juce::AudioBuffer<float> spatialAngleModulationTransition(double duration, double sampleRate, const juce::NamedValueSet& params);
+juce::AudioBuffer<float> spatialAngleModulationMonauralBeat(double duration, double sampleRate, const juce::NamedValueSet& params);
+juce::AudioBuffer<float> spatialAngleModulationMonauralBeatTransition(double duration, double sampleRate, const juce::NamedValueSet& params);
+
+juce::AudioBuffer<float> generateSweptNotchPinkSound(double duration, double sampleRate, const juce::NamedValueSet& params);
+juce::AudioBuffer<float> generateSweptNotchPinkSoundTransition(double duration, double sampleRate, const juce::NamedValueSet& params);
+
+juce::AudioBuffer<float> subliminalEncode(double duration, double sampleRate, const juce::NamedValueSet& params);

--- a/src/cpp_audio/main.cpp
+++ b/src/cpp_audio/main.cpp
@@ -9,7 +9,27 @@ using SynthFunc = juce::AudioBuffer<float>(*)(double, double, const juce::NamedV
 
 static std::map<juce::String, SynthFunc> synthMap {
     { "binaural_beat", binauralBeat },
-    { "isochronic_tone", isochronicTone }
+    { "binaural_beat_transition", binauralBeatTransition },
+    { "isochronic_tone", isochronicTone },
+    { "rhythmic_waveshaping", rhythmicWaveshaping },
+    { "rhythmic_waveshaping_transition", rhythmicWaveshapingTransition },
+    { "stereo_am_independent", stereoAMIndependent },
+    { "stereo_am_independent_transition", stereoAMIndependentTransition },
+    { "wave_shape_stereo_am", waveShapeStereoAm },
+    { "wave_shape_stereo_am_transition", waveShapeStereoAmTransition },
+    { "monaural_beat_stereo_amps", monauralBeatStereoAmps },
+    { "monaural_beat_stereo_amps_transition", monauralBeatStereoAmpsTransition },
+    { "qam_beat", qamBeat },
+    { "qam_beat_transition", qamBeatTransition },
+    { "hybrid_qam_monaural_beat", hybridQamMonauralBeat },
+    { "hybrid_qam_monaural_beat_transition", hybridQamMonauralBeatTransition },
+    { "spatial_angle_modulation", spatialAngleModulation },
+    { "spatial_angle_modulation_transition", spatialAngleModulationTransition },
+    { "spatial_angle_modulation_monaural_beat", spatialAngleModulationMonauralBeat },
+    { "spatial_angle_modulation_monaural_beat_transition", spatialAngleModulationMonauralBeatTransition },
+    { "generate_swept_notch_pink_sound", generateSweptNotchPinkSound },
+    { "generate_swept_notch_pink_sound_transition", generateSweptNotchPinkSoundTransition },
+    { "subliminal_encode", subliminalEncode }
 };
 
 int main (int argc, char* argv[])

--- a/src/cpp_audio/synths/BinauralBeat.cpp
+++ b/src/cpp_audio/synths/BinauralBeat.cpp
@@ -1,0 +1,214 @@
+#include "SynthFunctions.h"
+#include "AudioUtils.h"
+#include <vector>
+#include <cmath>
+#include <algorithm>
+
+using namespace juce;
+
+AudioBuffer<float> binauralBeat(double duration, double sampleRate, const NamedValueSet& params)
+{
+    int N = static_cast<int>(duration * sampleRate);
+    AudioBuffer<float> buffer(2, std::max(0, N));
+    if (N <= 0)
+        return buffer;
+
+    double ampL  = params.getWithDefault("ampL", 0.5);
+    double ampR  = params.getWithDefault("ampR", 0.5);
+    double baseF = params.getWithDefault("baseFreq", 200.0);
+    double beatF = params.getWithDefault("beatFreq", 4.0);
+    bool   forceMono = params.getWithDefault("forceMono", false);
+    double startL = params.getWithDefault("startPhaseL", 0.0);
+    double startR = params.getWithDefault("startPhaseR", 0.0);
+    double aODL  = params.getWithDefault("ampOscDepthL", 0.0);
+    double aOFL  = params.getWithDefault("ampOscFreqL", 0.0);
+    double aODR  = params.getWithDefault("ampOscDepthR", 0.0);
+    double aOFR  = params.getWithDefault("ampOscFreqR", 0.0);
+    double fORL  = params.getWithDefault("freqOscRangeL", 0.0);
+    double fOFL  = params.getWithDefault("freqOscFreqL", 0.0);
+    double fORR  = params.getWithDefault("freqOscRangeR", 0.0);
+    double fOFR  = params.getWithDefault("freqOscFreqR", 0.0);
+    double ampOscPhaseOffsetL = params.getWithDefault("ampOscPhaseOffsetL", 0.0);
+    double ampOscPhaseOffsetR = params.getWithDefault("ampOscPhaseOffsetR", 0.0);
+    double pOF  = params.getWithDefault("phaseOscFreq", 0.0);
+    double pOR  = params.getWithDefault("phaseOscRange", 0.0);
+
+    std::vector<double> t(N);
+    std::vector<double> instL(N), instR(N);
+    std::vector<double> phaseL(N), phaseR(N);
+    std::vector<double> envL(N), envR(N);
+
+    double dt = duration / static_cast<double>(N);
+    for (int i = 0; i < N; ++i)
+        t[i] = i * dt;
+
+    double halfB = beatF * 0.5;
+    double fLbase = baseF - halfB;
+    double fRbase = baseF + halfB;
+    for (int i = 0; i < N; ++i)
+    {
+        double vibL = (fORL * 0.5) * std::sin(2.0 * MathConstants<double>::pi * fOFL * t[i]);
+        double vibR = (fORR * 0.5) * std::sin(2.0 * MathConstants<double>::pi * fOFR * t[i]);
+        instL[i] = std::max(0.0, fLbase + vibL);
+        instR[i] = std::max(0.0, fRbase + vibR);
+    }
+
+    if (forceMono || beatF == 0.0)
+        for (int i = 0; i < N; ++i)
+            instL[i] = instR[i] = std::max(0.0, baseF);
+
+    double curL = startL;
+    double curR = startR;
+    for (int i = 0; i < N; ++i)
+    {
+        curL += 2.0 * MathConstants<double>::pi * instL[i] * dt;
+        curR += 2.0 * MathConstants<double>::pi * instR[i] * dt;
+        phaseL[i] = curL;
+        phaseR[i] = curR;
+    }
+
+    if (pOF != 0.0 || pOR != 0.0)
+    {
+        for (int i = 0; i < N; ++i)
+        {
+            double dphi = (pOR * 0.5) * std::sin(2.0 * MathConstants<double>::pi * pOF * t[i]);
+            phaseL[i] -= dphi;
+            phaseR[i] += dphi;
+        }
+    }
+
+    for (int i = 0; i < N; ++i)
+    {
+        envL[i] = 1.0 - aODL * (0.5 * (1.0 + std::sin(2.0 * MathConstants<double>::pi * aOFL * t[i] + ampOscPhaseOffsetL)));
+        envR[i] = 1.0 - aODR * (0.5 * (1.0 + std::sin(2.0 * MathConstants<double>::pi * aOFR * t[i] + ampOscPhaseOffsetR)));
+    }
+
+    for (int i = 0; i < N; ++i)
+    {
+        float outL = static_cast<float>(std::sin(phaseL[i]) * envL[i] * ampL);
+        float outR = static_cast<float>(std::sin(phaseR[i]) * envR[i] * ampR);
+        buffer.setSample(0, i, outL);
+        buffer.setSample(1, i, outR);
+    }
+
+    return buffer;
+}
+
+AudioBuffer<float> binauralBeatTransition(double duration, double sampleRate, const NamedValueSet& params)
+{
+    int N = static_cast<int>(duration * sampleRate);
+    AudioBuffer<float> buffer(2, std::max(0, N));
+    if (N <= 0)
+        return buffer;
+
+    double startAmpL = params.getWithDefault("startAmpL", params.getWithDefault("ampL", 0.5));
+    double endAmpL   = params.getWithDefault("endAmpL", startAmpL);
+    double startAmpR = params.getWithDefault("startAmpR", params.getWithDefault("ampR", 0.5));
+    double endAmpR   = params.getWithDefault("endAmpR", startAmpR);
+    double startBaseF = params.getWithDefault("startBaseFreq", params.getWithDefault("baseFreq", 200.0));
+    double endBaseF   = params.getWithDefault("endBaseFreq", startBaseF);
+    double startBeatF = params.getWithDefault("startBeatFreq", params.getWithDefault("beatFreq", 4.0));
+    double endBeatF   = params.getWithDefault("endBeatFreq", startBeatF);
+    double startForceMono = params.getWithDefault("startForceMono", params.getWithDefault("forceMono", 0.0));
+    double endForceMono   = params.getWithDefault("endForceMono", startForceMono);
+    double startStartPhaseL = params.getWithDefault("startStartPhaseL", params.getWithDefault("startPhaseL", 0.0));
+    double endStartPhaseL   = params.getWithDefault("endStartPhaseL", startStartPhaseL);
+    double startStartPhaseR = params.getWithDefault("startStartPhaseR", params.getWithDefault("startPhaseR", 0.0));
+    double endStartPhaseR   = params.getWithDefault("endStartPhaseR", startStartPhaseR);
+    double startPOF = params.getWithDefault("startPhaseOscFreq", params.getWithDefault("phaseOscFreq", 0.0));
+    double endPOF   = params.getWithDefault("endPhaseOscFreq", startPOF);
+    double startPOR = params.getWithDefault("startPhaseOscRange", params.getWithDefault("phaseOscRange", 0.0));
+    double endPOR   = params.getWithDefault("endPhaseOscRange", startPOR);
+    double startAODL = params.getWithDefault("startAmpOscDepthL", params.getWithDefault("ampOscDepthL", 0.0));
+    double endAODL   = params.getWithDefault("endAmpOscDepthL", startAODL);
+    double startAOFL = params.getWithDefault("startAmpOscFreqL", params.getWithDefault("ampOscFreqL", 0.0));
+    double endAOFL   = params.getWithDefault("endAmpOscFreqL", startAOFL);
+    double startAODR = params.getWithDefault("startAmpOscDepthR", params.getWithDefault("ampOscDepthR", 0.0));
+    double endAODR   = params.getWithDefault("endAmpOscDepthR", startAODR);
+    double startAOFR = params.getWithDefault("startAmpOscFreqR", params.getWithDefault("ampOscFreqR", 0.0));
+    double endAOFR   = params.getWithDefault("endAmpOscFreqR", startAOFR);
+    double startAmpOscPhaseOffsetL = params.getWithDefault("startAmpOscPhaseOffsetL", params.getWithDefault("ampOscPhaseOffsetL", 0.0));
+    double endAmpOscPhaseOffsetL   = params.getWithDefault("endAmpOscPhaseOffsetL", startAmpOscPhaseOffsetL);
+    double startAmpOscPhaseOffsetR = params.getWithDefault("startAmpOscPhaseOffsetR", params.getWithDefault("ampOscPhaseOffsetR", 0.0));
+    double endAmpOscPhaseOffsetR   = params.getWithDefault("endAmpOscPhaseOffsetR", startAmpOscPhaseOffsetR);
+    double startFORL = params.getWithDefault("startFreqOscRangeL", params.getWithDefault("freqOscRangeL", 0.0));
+    double endFORL   = params.getWithDefault("endFreqOscRangeL", startFORL);
+    double startFOFL = params.getWithDefault("startFreqOscFreqL", params.getWithDefault("freqOscFreqL", 0.0));
+    double endFOFL   = params.getWithDefault("endFreqOscFreqL", startFOFL);
+    double startFORR = params.getWithDefault("startFreqOscRangeR", params.getWithDefault("freqOscRangeR", 0.0));
+    double endFORR   = params.getWithDefault("endFreqOscRangeR", startFORR);
+    double startFOFR = params.getWithDefault("startFreqOscFreqR", params.getWithDefault("freqOscFreqR", 0.0));
+    double endFOFR   = params.getWithDefault("endFreqOscFreqR", startFOFR);
+    double initialOffset = params.getWithDefault("initial_offset", 0.0);
+    double postOffset    = params.getWithDefault("post_offset", 0.0);
+    String curve = params.getWithDefault("transition_curve", "linear");
+
+    auto alpha = calculateTransitionAlpha(duration, sampleRate, initialOffset, postOffset, curve);
+    std::vector<double> t(N);
+    for (int i = 0; i < N; ++i)
+        t[i] = i * (duration / static_cast<double>(N));
+
+    std::vector<double> instL(N), instR(N), phaseL(N), phaseR(N), envL(N), envR(N);
+    std::vector<double> outAmpL(N), outAmpR(N);
+
+    for (int i = 0; i < N; ++i)
+    {
+        double a = alpha.empty() ? static_cast<double>(i) / (N > 1 ? N - 1 : 1) : alpha[i];
+        outAmpL[i] = startAmpL + (endAmpL - startAmpL) * a;
+        outAmpR[i] = startAmpR + (endAmpR - startAmpR) * a;
+        double baseF = startBaseF + (endBaseF - startBaseF) * a;
+        double beatF = startBeatF + (endBeatF - startBeatF) * a;
+        double forceM = startForceMono + (endForceMono - startForceMono) * a;
+        double forL = startFORL + (endFORL - startFORL) * a;
+        double fofL = startFOFL + (endFOFL - startFOFL) * a;
+        double forR = startFORR + (endFORR - startFORR) * a;
+        double fofR = startFOFR + (endFOFR - startFOFR) * a;
+
+        double halfB = beatF * 0.5;
+        double fLbase = baseF - halfB;
+        double fRbase = baseF + halfB;
+        double vibL = (forL * 0.5) * std::sin(2.0 * MathConstants<double>::pi * fofL * t[i]);
+        double vibR = (forR * 0.5) * std::sin(2.0 * MathConstants<double>::pi * fofR * t[i]);
+        instL[i] = (forceM > 0.5 || beatF == 0.0) ? std::max(0.0, baseF) : std::max(0.0, fLbase + vibL);
+        instR[i] = (forceM > 0.5 || beatF == 0.0) ? std::max(0.0, baseF) : std::max(0.0, fRbase + vibR);
+
+        envL[i] = 1.0 - (startAODL + (endAODL - startAODL) * a) *
+                        (0.5 * (1.0 + std::sin(2.0 * MathConstants<double>::pi * (startAOFL + (endAOFL - startAOFL) * a) * t[i] +
+                                            (startAmpOscPhaseOffsetL + (endAmpOscPhaseOffsetL - startAmpOscPhaseOffsetL) * a))));
+        envR[i] = 1.0 - (startAODR + (endAODR - startAODR) * a) *
+                        (0.5 * (1.0 + std::sin(2.0 * MathConstants<double>::pi * (startAOFR + (endAOFR - startAOFR) * a) * t[i] +
+                                            (startAmpOscPhaseOffsetR + (endAmpOscPhaseOffsetR - startAmpOscPhaseOffsetR) * a))));
+    }
+
+    double curL = startStartPhaseL;
+    double curR = startStartPhaseR;
+    double dt = duration / static_cast<double>(N);
+    for (int i = 0; i < N; ++i)
+    {
+        curL += 2.0 * MathConstants<double>::pi * instL[i] * dt;
+        curR += 2.0 * MathConstants<double>::pi * instR[i] * dt;
+        phaseL[i] = curL;
+        phaseR[i] = curR;
+    }
+
+    for (int i = 0; i < N; ++i)
+    {
+        double a = alpha.empty() ? static_cast<double>(i) / (N > 1 ? N - 1 : 1) : alpha[i];
+        double pOFv = startPOF + (endPOF - startPOF) * a;
+        double pORv = startPOR + (endPOR - startPOR) * a;
+        double dphi = (pORv * 0.5) * std::sin(2.0 * MathConstants<double>::pi * pOFv * t[i]);
+        phaseL[i] -= dphi;
+        phaseR[i] += dphi;
+    }
+
+    for (int i = 0; i < N; ++i)
+    {
+        float outL = static_cast<float>(std::sin(phaseL[i]) * envL[i] * outAmpL[i]);
+        float outR = static_cast<float>(std::sin(phaseR[i]) * envR[i] * outAmpR[i]);
+        buffer.setSample(0, i, outL);
+        buffer.setSample(1, i, outR);
+    }
+
+    return buffer;
+}
+

--- a/src/cpp_audio/synths/HybridQamMonauralBeat.cpp
+++ b/src/cpp_audio/synths/HybridQamMonauralBeat.cpp
@@ -1,0 +1,20 @@
+#include "SynthFunctions.h"
+#include "AudioUtils.h"
+
+using namespace juce;
+
+AudioBuffer<float> hybridQamMonauralBeat(double duration, double sampleRate, const NamedValueSet& params)
+{
+    // TODO: implement hybrid qam monaural beat
+    AudioBuffer<float> buf(2, static_cast<int>(duration * sampleRate));
+    buf.clear();
+    return buf;
+}
+
+AudioBuffer<float> hybridQamMonauralBeatTransition(double duration, double sampleRate, const NamedValueSet& params)
+{
+    // TODO: implement transition
+    AudioBuffer<float> buf(2, static_cast<int>(duration * sampleRate));
+    buf.clear();
+    return buf;
+}

--- a/src/cpp_audio/synths/IsochronicTone.cpp
+++ b/src/cpp_audio/synths/IsochronicTone.cpp
@@ -2,23 +2,9 @@
 #include "AudioUtils.h"
 #include <cmath>
 
-juce::AudioBuffer<float> binauralBeat(double duration, double sampleRate, const juce::NamedValueSet& params)
-{
-    double ampL = params.getWithDefault("ampL", 0.5);
-    double ampR = params.getWithDefault("ampR", 0.5);
-    double baseFreq = params.getWithDefault("baseFreq", 200.0);
-    double beatFreq = params.getWithDefault("beatFreq", 4.0);
+using namespace juce;
 
-    auto left = generateSine(baseFreq - beatFreq/2.0, ampL, duration, sampleRate);
-    auto right = generateSine(baseFreq + beatFreq/2.0, ampR, duration, sampleRate);
-
-    juce::AudioBuffer<float> result(2, left.getNumSamples());
-    result.copyFrom(0, 0, left, 0, 0, left.getNumSamples());
-    result.copyFrom(1, 0, right, 1, 0, right.getNumSamples());
-    return result;
-}
-
-juce::AudioBuffer<float> isochronicTone(double duration, double sampleRate, const juce::NamedValueSet& params)
+AudioBuffer<float> isochronicTone(double duration, double sampleRate, const NamedValueSet& params)
 {
     double amp = params.getWithDefault("amp", 0.5);
     double baseFreq = params.getWithDefault("baseFreq", 200.0);
@@ -27,7 +13,7 @@ juce::AudioBuffer<float> isochronicTone(double duration, double sampleRate, cons
     double gapPercent = params.getWithDefault("gapPercent", 0.15);
 
     int totalSamples = static_cast<int>(duration * sampleRate);
-    juce::AudioBuffer<float> buffer(2, totalSamples);
+    AudioBuffer<float> buffer(2, totalSamples);
 
     double phase = 0.0;
     double dt = 1.0 / sampleRate;
@@ -48,8 +34,7 @@ juce::AudioBuffer<float> isochronicTone(double duration, double sampleRate, cons
         float sample = static_cast<float>(std::sin(phase) * amp * env);
         buffer.setSample(0, i, sample);
         buffer.setSample(1, i, sample);
-        phase += juce::MathConstants<double>::twoPi * baseFreq * dt;
+        phase += MathConstants<double>::twoPi * baseFreq * dt;
     }
     return buffer;
 }
-

--- a/src/cpp_audio/synths/MonauralBeatStereoAmps.cpp
+++ b/src/cpp_audio/synths/MonauralBeatStereoAmps.cpp
@@ -1,0 +1,20 @@
+#include "SynthFunctions.h"
+#include "AudioUtils.h"
+
+using namespace juce;
+
+AudioBuffer<float> monauralBeatStereoAmps(double duration, double sampleRate, const NamedValueSet& params)
+{
+    // TODO: full implementation pending
+    AudioBuffer<float> buf(2, static_cast<int>(duration * sampleRate));
+    buf.clear();
+    return buf;
+}
+
+AudioBuffer<float> monauralBeatStereoAmpsTransition(double duration, double sampleRate, const NamedValueSet& params)
+{
+    // TODO: full implementation pending
+    AudioBuffer<float> buf(2, static_cast<int>(duration * sampleRate));
+    buf.clear();
+    return buf;
+}

--- a/src/cpp_audio/synths/NoiseFlanger.cpp
+++ b/src/cpp_audio/synths/NoiseFlanger.cpp
@@ -1,0 +1,20 @@
+#include "SynthFunctions.h"
+#include "AudioUtils.h"
+
+using namespace juce;
+
+AudioBuffer<float> generateSweptNotchPinkSound(double duration, double sampleRate, const NamedValueSet& params)
+{
+    // TODO: implement noise flanger effect
+    AudioBuffer<float> buf(2, static_cast<int>(duration * sampleRate));
+    buf.clear();
+    return buf;
+}
+
+AudioBuffer<float> generateSweptNotchPinkSoundTransition(double duration, double sampleRate, const NamedValueSet& params)
+{
+    // TODO: implement transition version
+    AudioBuffer<float> buf(2, static_cast<int>(duration * sampleRate));
+    buf.clear();
+    return buf;
+}

--- a/src/cpp_audio/synths/QamBeat.cpp
+++ b/src/cpp_audio/synths/QamBeat.cpp
@@ -1,0 +1,20 @@
+#include "SynthFunctions.h"
+#include "AudioUtils.h"
+
+using namespace juce;
+
+AudioBuffer<float> qamBeat(double duration, double sampleRate, const NamedValueSet& params)
+{
+    // TODO: implement QAM beat synthesis
+    AudioBuffer<float> buf(2, static_cast<int>(duration * sampleRate));
+    buf.clear();
+    return buf;
+}
+
+AudioBuffer<float> qamBeatTransition(double duration, double sampleRate, const NamedValueSet& params)
+{
+    // TODO: implement transition variant
+    AudioBuffer<float> buf(2, static_cast<int>(duration * sampleRate));
+    buf.clear();
+    return buf;
+}

--- a/src/cpp_audio/synths/RhythmicWaveshaping.cpp
+++ b/src/cpp_audio/synths/RhythmicWaveshaping.cpp
@@ -1,0 +1,94 @@
+#include "SynthFunctions.h"
+#include "AudioUtils.h"
+#include <cmath>
+
+using namespace juce;
+
+AudioBuffer<float> rhythmicWaveshaping(double duration, double sampleRate, const NamedValueSet& params)
+{
+    double amp = params.getWithDefault("amp", 0.25);
+    double carrierFreq = params.getWithDefault("carrierFreq", 200.0);
+    double modFreq = params.getWithDefault("modFreq", 4.0);
+    double modDepth = params.getWithDefault("modDepth", 1.0);
+    double shapeAmount = params.getWithDefault("shapeAmount", 5.0);
+    double pan = params.getWithDefault("pan", 0.0);
+
+    int totalSamples = static_cast<int>(duration * sampleRate);
+    AudioBuffer<float> buffer(2, totalSamples);
+    auto gains = getPanGains(pan);
+
+    double dt = 1.0 / sampleRate;
+    double carrierPhase = 0.0;
+    double modPhase = 0.0;
+    double tanhShape = std::tanh(std::max(1e-6, shapeAmount));
+
+    for (int i = 0; i < totalSamples; ++i)
+    {
+        double carrier = std::sin(carrierPhase);
+        double lfo = std::sin(modPhase);
+        double shapeLFO = 1.0 - modDepth * (1.0 - lfo) * 0.5;
+        double modulated = carrier * shapeLFO;
+        double shaped = std::tanh(modulated * shapeAmount) / tanhShape;
+        float s = static_cast<float>(shaped * amp);
+        buffer.setSample(0, i, s * gains.first);
+        buffer.setSample(1, i, s * gains.second);
+
+        carrierPhase += MathConstants<double>::twoPi * carrierFreq * dt;
+        modPhase += MathConstants<double>::twoPi * modFreq * dt;
+    }
+
+    return buffer;
+}
+
+AudioBuffer<float> rhythmicWaveshapingTransition(double duration, double sampleRate, const NamedValueSet& params)
+{
+    double amp = params.getWithDefault("amp", 0.25);
+    double startCarrierFreq = params.getWithDefault("startCarrierFreq", 200.0);
+    double endCarrierFreq = params.getWithDefault("endCarrierFreq", 80.0);
+    double startModFreq = params.getWithDefault("startModFreq", 12.0);
+    double endModFreq = params.getWithDefault("endModFreq", 7.83);
+    double startModDepth = params.getWithDefault("startModDepth", 1.0);
+    double endModDepth = params.getWithDefault("endModDepth", 1.0);
+    double startShapeAmount = params.getWithDefault("startShapeAmount", 5.0);
+    double endShapeAmount = params.getWithDefault("endShapeAmount", 5.0);
+    double pan = params.getWithDefault("pan", 0.0);
+
+    double initialOffset = params.getWithDefault("initial_offset", 0.0);
+    double postOffset = params.getWithDefault("post_offset", 0.0);
+    String curve = params.getWithDefault("transition_curve", "linear");
+
+    int totalSamples = static_cast<int>(duration * sampleRate);
+    AudioBuffer<float> buffer(2, totalSamples);
+    auto alpha = calculateTransitionAlpha(duration, sampleRate, initialOffset, postOffset, curve);
+    auto gains = getPanGains(pan);
+
+    double dt = 1.0 / sampleRate;
+    double carrierPhase = 0.0;
+    double modPhase = 0.0;
+
+    for (int i = 0; i < totalSamples; ++i)
+    {
+        double a = alpha.empty() ? static_cast<double>(i) / (totalSamples > 1 ? totalSamples - 1 : 1)
+                                 : alpha[i];
+
+        double carrierFreq = startCarrierFreq + (endCarrierFreq - startCarrierFreq) * a;
+        double modFreq = startModFreq + (endModFreq - startModFreq) * a;
+        double modDepth = startModDepth + (endModDepth - startModDepth) * a;
+        double shapeAmount = startShapeAmount + (endShapeAmount - startShapeAmount) * a;
+        double tanhShape = std::tanh(std::max(1e-6, shapeAmount));
+
+        double carrier = std::sin(carrierPhase);
+        double lfo = std::sin(modPhase);
+        double shapeLFO = 1.0 - modDepth * (1.0 - lfo) * 0.5;
+        double modulated = carrier * shapeLFO;
+        double shaped = std::tanh(modulated * shapeAmount) / tanhShape;
+        float s = static_cast<float>(shaped * amp);
+        buffer.setSample(0, i, s * gains.first);
+        buffer.setSample(1, i, s * gains.second);
+
+        carrierPhase += MathConstants<double>::twoPi * carrierFreq * dt;
+        modPhase += MathConstants<double>::twoPi * modFreq * dt;
+    }
+
+    return buffer;
+}

--- a/src/cpp_audio/synths/SpatialAngleModulation.cpp
+++ b/src/cpp_audio/synths/SpatialAngleModulation.cpp
@@ -1,0 +1,36 @@
+#include "SynthFunctions.h"
+#include "AudioUtils.h"
+
+using namespace juce;
+
+AudioBuffer<float> spatialAngleModulation(double duration, double sampleRate, const NamedValueSet& params)
+{
+    // TODO: implement SAM voice
+    AudioBuffer<float> buf(2, static_cast<int>(duration * sampleRate));
+    buf.clear();
+    return buf;
+}
+
+AudioBuffer<float> spatialAngleModulationTransition(double duration, double sampleRate, const NamedValueSet& params)
+{
+    // TODO: implement SAM transition
+    AudioBuffer<float> buf(2, static_cast<int>(duration * sampleRate));
+    buf.clear();
+    return buf;
+}
+
+AudioBuffer<float> spatialAngleModulationMonauralBeat(double duration, double sampleRate, const NamedValueSet& params)
+{
+    // TODO: implement SAM monaural beat
+    AudioBuffer<float> buf(2, static_cast<int>(duration * sampleRate));
+    buf.clear();
+    return buf;
+}
+
+AudioBuffer<float> spatialAngleModulationMonauralBeatTransition(double duration, double sampleRate, const NamedValueSet& params)
+{
+    // TODO: implement SAM monaural beat transition
+    AudioBuffer<float> buf(2, static_cast<int>(duration * sampleRate));
+    buf.clear();
+    return buf;
+}

--- a/src/cpp_audio/synths/StereoAMIndependent.cpp
+++ b/src/cpp_audio/synths/StereoAMIndependent.cpp
@@ -1,0 +1,118 @@
+#include "SynthFunctions.h"
+#include "AudioUtils.h"
+#include <cmath>
+
+using namespace juce;
+
+AudioBuffer<float> stereoAMIndependent(double duration, double sampleRate, const NamedValueSet& params)
+{
+    double amp = params.getWithDefault("amp", 0.25);
+    double carrierFreq = params.getWithDefault("carrierFreq", 200.0);
+    double modFreqL = params.getWithDefault("modFreqL", 4.0);
+    double modDepthL = params.getWithDefault("modDepthL", 0.8);
+    double modPhaseL = params.getWithDefault("modPhaseL", 0.0);
+    double modFreqR = params.getWithDefault("modFreqR", 4.0);
+    double modDepthR = params.getWithDefault("modDepthR", 0.8);
+    double modPhaseR = params.getWithDefault("modPhaseR", 0.0);
+    double stereoWidthHz = params.getWithDefault("stereo_width_hz", 0.2);
+
+    int totalSamples = static_cast<int>(duration * sampleRate);
+    AudioBuffer<float> buffer(2, totalSamples);
+
+    double dt = 1.0 / sampleRate;
+    double carrierPhaseL = 0.0;
+    double carrierPhaseR = 0.0;
+    double lfoPhaseL = modPhaseL;
+    double lfoPhaseR = modPhaseR;
+
+    for (int i = 0; i < totalSamples; ++i)
+    {
+        double carrierL = std::sin(carrierPhaseL);
+        double carrierR = std::sin(carrierPhaseR);
+        double lfoL = std::sin(lfoPhaseL);
+        double lfoR = std::sin(lfoPhaseR);
+
+        double modL = 1.0 - modDepthL * (1.0 - lfoL) * 0.5;
+        double modR = 1.0 - modDepthR * (1.0 - lfoR) * 0.5;
+
+        float outL = static_cast<float>(carrierL * modL * amp);
+        float outR = static_cast<float>(carrierR * modR * amp);
+
+        buffer.setSample(0, i, outL);
+        buffer.setSample(1, i, outR);
+
+        carrierPhaseL += MathConstants<double>::twoPi * (carrierFreq - stereoWidthHz * 0.5) * dt;
+        carrierPhaseR += MathConstants<double>::twoPi * (carrierFreq + stereoWidthHz * 0.5) * dt;
+        lfoPhaseL += MathConstants<double>::twoPi * modFreqL * dt;
+        lfoPhaseR += MathConstants<double>::twoPi * modFreqR * dt;
+    }
+
+    return buffer;
+}
+
+AudioBuffer<float> stereoAMIndependentTransition(double duration, double sampleRate, const NamedValueSet& params)
+{
+    double amp = params.getWithDefault("amp", 0.25);
+    double startCarrierFreq = params.getWithDefault("startCarrierFreq", 200.0);
+    double endCarrierFreq = params.getWithDefault("endCarrierFreq", 250.0);
+    double startModFreqL = params.getWithDefault("startModFreqL", 4.0);
+    double endModFreqL = params.getWithDefault("endModFreqL", 6.0);
+    double startModDepthL = params.getWithDefault("startModDepthL", 0.8);
+    double endModDepthL = params.getWithDefault("endModDepthL", 0.8);
+    double startModPhaseL = params.getWithDefault("startModPhaseL", 0.0);
+    double startModFreqR = params.getWithDefault("startModFreqR", 4.1);
+    double endModFreqR = params.getWithDefault("endModFreqR", 5.9);
+    double startModDepthR = params.getWithDefault("startModDepthR", 0.8);
+    double endModDepthR = params.getWithDefault("endModDepthR", 0.8);
+    double startModPhaseR = params.getWithDefault("startModPhaseR", 0.0);
+    double startStereoWidthHz = params.getWithDefault("startStereoWidthHz", 0.2);
+    double endStereoWidthHz = params.getWithDefault("endStereoWidthHz", 0.2);
+
+    double initialOffset = params.getWithDefault("initial_offset", 0.0);
+    double postOffset = params.getWithDefault("post_offset", 0.0);
+    String curve = params.getWithDefault("transition_curve", "linear");
+
+    int totalSamples = static_cast<int>(duration * sampleRate);
+    AudioBuffer<float> buffer(2, totalSamples);
+    auto alpha = calculateTransitionAlpha(duration, sampleRate, initialOffset, postOffset, curve);
+
+    double dt = 1.0 / sampleRate;
+    double carrierPhaseL = 0.0;
+    double carrierPhaseR = 0.0;
+    double lfoPhaseL = startModPhaseL;
+    double lfoPhaseR = startModPhaseR;
+
+    for (int i = 0; i < totalSamples; ++i)
+    {
+        double a = alpha.empty() ? static_cast<double>(i) / (totalSamples > 1 ? totalSamples - 1 : 1)
+                                 : alpha[i];
+
+        double carrierFreq = startCarrierFreq + (endCarrierFreq - startCarrierFreq) * a;
+        double modFreqL = startModFreqL + (endModFreqL - startModFreqL) * a;
+        double modDepthL = startModDepthL + (endModDepthL - startModDepthL) * a;
+        double modFreqR = startModFreqR + (endModFreqR - startModFreqR) * a;
+        double modDepthR = startModDepthR + (endModDepthR - startModDepthR) * a;
+        double stereoWidthHz = startStereoWidthHz + (endStereoWidthHz - startStereoWidthHz) * a;
+
+        double carrierL = std::sin(carrierPhaseL);
+        double carrierR = std::sin(carrierPhaseR);
+        double lfoL = std::sin(lfoPhaseL);
+        double lfoR = std::sin(lfoPhaseR);
+
+        double modL = 1.0 - modDepthL * (1.0 - lfoL) * 0.5;
+        double modR = 1.0 - modDepthR * (1.0 - lfoR) * 0.5;
+
+        float outL = static_cast<float>(carrierL * modL * amp);
+        float outR = static_cast<float>(carrierR * modR * amp);
+
+        buffer.setSample(0, i, outL);
+        buffer.setSample(1, i, outR);
+
+        carrierPhaseL += MathConstants<double>::twoPi * (carrierFreq - stereoWidthHz * 0.5) * dt;
+        carrierPhaseR += MathConstants<double>::twoPi * (carrierFreq + stereoWidthHz * 0.5) * dt;
+        lfoPhaseL += MathConstants<double>::twoPi * modFreqL * dt;
+        lfoPhaseR += MathConstants<double>::twoPi * modFreqR * dt;
+    }
+
+    return buffer;
+}

--- a/src/cpp_audio/synths/Subliminals.cpp
+++ b/src/cpp_audio/synths/Subliminals.cpp
@@ -1,0 +1,12 @@
+#include "SynthFunctions.h"
+#include "AudioUtils.h"
+
+using namespace juce;
+
+AudioBuffer<float> subliminalEncode(double duration, double sampleRate, const NamedValueSet& params)
+{
+    // TODO: implement subliminal encoding
+    AudioBuffer<float> buf(2, static_cast<int>(duration * sampleRate));
+    buf.clear();
+    return buf;
+}

--- a/src/cpp_audio/synths/WaveShapeStereoAm.cpp
+++ b/src/cpp_audio/synths/WaveShapeStereoAm.cpp
@@ -1,0 +1,132 @@
+#include "SynthFunctions.h"
+#include "AudioUtils.h"
+#include <cmath>
+
+using namespace juce;
+
+AudioBuffer<float> waveShapeStereoAm(double duration, double sampleRate, const NamedValueSet& params)
+{
+    double amp = params.getWithDefault("amp", 0.15);
+    double carrierFreq = params.getWithDefault("carrierFreq", 200.0);
+    double shapeModFreq = params.getWithDefault("shapeModFreq", 4.0);
+    double shapeModDepth = params.getWithDefault("shapeModDepth", 0.8);
+    double shapeAmount = params.getWithDefault("shapeAmount", 0.5);
+    double stereoModFreqL = params.getWithDefault("stereoModFreqL", 4.1);
+    double stereoModDepthL = params.getWithDefault("stereoModDepthL", 0.8);
+    double stereoModPhaseL = params.getWithDefault("stereoModPhaseL", 0.0);
+    double stereoModFreqR = params.getWithDefault("stereoModFreqR", 4.0);
+    double stereoModDepthR = params.getWithDefault("stereoModDepthR", 0.8);
+    double stereoModPhaseR = params.getWithDefault("stereoModPhaseR", MathConstants<double>::halfPi);
+
+    int totalSamples = static_cast<int>(duration * sampleRate);
+    AudioBuffer<float> buffer(2, totalSamples);
+
+    double dt = 1.0 / sampleRate;
+    double carrierPhase = 0.0;
+    double shapePhase = 0.0;
+    double stereoPhaseL = stereoModPhaseL;
+    double stereoPhaseR = stereoModPhaseR;
+    double tanhShape = std::tanh(std::max(1e-6, shapeAmount));
+
+    for (int i = 0; i < totalSamples; ++i)
+    {
+        double carrier = std::sin(carrierPhase);
+        double shapeLFO = std::sin(shapePhase);
+        double shapeAmp = 1.0 - shapeModDepth * (1.0 - shapeLFO) * 0.5;
+        double shaped = std::tanh(carrier * shapeAmp * shapeAmount) / tanhShape;
+
+        double lfoL = std::sin(stereoPhaseL);
+        double lfoR = std::sin(stereoPhaseR);
+        double modL = 1.0 - stereoModDepthL * (1.0 - lfoL) * 0.5;
+        double modR = 1.0 - stereoModDepthR * (1.0 - lfoR) * 0.5;
+
+        float outL = static_cast<float>(shaped * modL * amp);
+        float outR = static_cast<float>(shaped * modR * amp);
+
+        buffer.setSample(0, i, outL);
+        buffer.setSample(1, i, outR);
+
+        carrierPhase += MathConstants<double>::twoPi * carrierFreq * dt;
+        shapePhase += MathConstants<double>::twoPi * shapeModFreq * dt;
+        stereoPhaseL += MathConstants<double>::twoPi * stereoModFreqL * dt;
+        stereoPhaseR += MathConstants<double>::twoPi * stereoModFreqR * dt;
+    }
+
+    return buffer;
+}
+
+AudioBuffer<float> waveShapeStereoAmTransition(double duration, double sampleRate, const NamedValueSet& params)
+{
+    double amp = params.getWithDefault("amp", 0.15);
+    double startCarrierFreq = params.getWithDefault("startCarrierFreq", 200.0);
+    double endCarrierFreq = params.getWithDefault("endCarrierFreq", 100.0);
+    double startShapeModFreq = params.getWithDefault("startShapeModFreq", 4.0);
+    double endShapeModFreq = params.getWithDefault("endShapeModFreq", 8.0);
+    double startShapeModDepth = params.getWithDefault("startShapeModDepth", 0.8);
+    double endShapeModDepth = params.getWithDefault("endShapeModDepth", 0.8);
+    double startShapeAmount = params.getWithDefault("startShapeAmount", 0.5);
+    double endShapeAmount = params.getWithDefault("endShapeAmount", 0.5);
+    double startStereoModFreqL = params.getWithDefault("startStereoModFreqL", 4.1);
+    double endStereoModFreqL = params.getWithDefault("endStereoModFreqL", 6.0);
+    double startStereoModDepthL = params.getWithDefault("startStereoModDepthL", 0.8);
+    double endStereoModDepthL = params.getWithDefault("endStereoModDepthL", 0.8);
+    double startStereoModPhaseL = params.getWithDefault("startStereoModPhaseL", 0.0);
+    double startStereoModFreqR = params.getWithDefault("startStereoModFreqR", 4.0);
+    double endStereoModFreqR = params.getWithDefault("endStereoModFreqR", 6.1);
+    double startStereoModDepthR = params.getWithDefault("startStereoModDepthR", 0.9);
+    double endStereoModDepthR = params.getWithDefault("endStereoModDepthR", 0.9);
+    double startStereoModPhaseR = params.getWithDefault("startStereoModPhaseR", MathConstants<double>::halfPi);
+
+    double initialOffset = params.getWithDefault("initial_offset", 0.0);
+    double postOffset = params.getWithDefault("post_offset", 0.0);
+    String curve = params.getWithDefault("transition_curve", "linear");
+
+    int totalSamples = static_cast<int>(duration * sampleRate);
+    AudioBuffer<float> buffer(2, totalSamples);
+    auto alpha = calculateTransitionAlpha(duration, sampleRate, initialOffset, postOffset, curve);
+
+    double dt = 1.0 / sampleRate;
+    double carrierPhase = 0.0;
+    double shapePhase = 0.0;
+    double stereoPhaseL = startStereoModPhaseL;
+    double stereoPhaseR = startStereoModPhaseR;
+
+    for (int i = 0; i < totalSamples; ++i)
+    {
+        double a = alpha.empty() ? static_cast<double>(i) / (totalSamples > 1 ? totalSamples - 1 : 1)
+                                 : alpha[i];
+
+        double carrierFreq = startCarrierFreq + (endCarrierFreq - startCarrierFreq) * a;
+        double shapeModFreq = startShapeModFreq + (endShapeModFreq - startShapeModFreq) * a;
+        double shapeModDepth = startShapeModDepth + (endShapeModDepth - startShapeModDepth) * a;
+        double shapeAmount = startShapeAmount + (endShapeAmount - startShapeAmount) * a;
+        double stereoModFreqL = startStereoModFreqL + (endStereoModFreqL - startStereoModFreqL) * a;
+        double stereoModDepthL = startStereoModDepthL + (endStereoModDepthL - startStereoModDepthL) * a;
+        double stereoModFreqR = startStereoModFreqR + (endStereoModFreqR - startStereoModFreqR) * a;
+        double stereoModDepthR = startStereoModDepthR + (endStereoModDepthR - startStereoModDepthR) * a;
+
+        double carrier = std::sin(carrierPhase);
+        double shapeLFO = std::sin(shapePhase);
+        double shapeAmp = 1.0 - shapeModDepth * (1.0 - shapeLFO) * 0.5;
+        double tanhShape = std::tanh(std::max(1e-6, shapeAmount));
+        double shaped = std::tanh(carrier * shapeAmp * shapeAmount) / tanhShape;
+
+        double lfoL = std::sin(stereoPhaseL);
+        double lfoR = std::sin(stereoPhaseR);
+        double modL = 1.0 - stereoModDepthL * (1.0 - lfoL) * 0.5;
+        double modR = 1.0 - stereoModDepthR * (1.0 - lfoR) * 0.5;
+
+        float outL = static_cast<float>(shaped * modL * amp);
+        float outR = static_cast<float>(shaped * modR * amp);
+
+        buffer.setSample(0, i, outL);
+        buffer.setSample(1, i, outR);
+
+        carrierPhase += MathConstants<double>::twoPi * carrierFreq * dt;
+        shapePhase += MathConstants<double>::twoPi * shapeModFreq * dt;
+        stereoPhaseL += MathConstants<double>::twoPi * stereoModFreqL * dt;
+        stereoPhaseR += MathConstants<double>::twoPi * stereoModFreqR * dt;
+    }
+
+    return buffer;
+}


### PR DESCRIPTION
## Summary
- split SynthFunctions.cpp into per-voice source files
- implement detailed binaural beat algorithm
- add placeholder stubs for remaining synths
- update CLI mapping and CMake sources list

## Testing
- `cmake -S src/cpp_audio -B build` *(fails: Could not find JUCE)*【929194†L1-L14】
- `python -m py_compile $(git ls-files '*.py')`【33db50†L1-L3】


------
https://chatgpt.com/codex/tasks/task_e_685b184a1da8832daa9affa1669db3d9