### PR TITLE
Add C++ UI skeleton files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,3 +2,4 @@ cmake_minimum_required(VERSION 3.14)
 project(DIY_AV_CPP)
 
 add_subdirectory(src/cpp_audio)
+add_subdirectory(src/cpp_ui)

--- a/src/cpp_ui/CMakeLists.txt
+++ b/src/cpp_ui/CMakeLists.txt
@@ -1,0 +1,33 @@
+cmake_minimum_required(VERSION 3.14)
+
+project(DIY_AV_UI_CPP)
+
+find_package(JUCE CONFIG REQUIRED)
+
+juce_add_gui_app(diy_av_ui_cpp
+    PRODUCT_NAME "DIY AV UI CPP"
+    BUNDLE_ID com.example.diyavcpp.ui
+    VERSION 0.1
+    SOURCES
+        Simulator.cpp
+        StepConfigPanel.cpp
+        StepListPanel.cpp
+        CollapsibleBox.cpp
+        DefaultVoiceDialog.cpp
+        FrequencyTesterDialog.cpp
+        NoiseGeneratorDialog.cpp
+        OverlayClipDialog.cpp
+        PreferencesDialog.cpp
+        SubliminalDialog.cpp
+        VoiceEditorDialog.cpp
+        Themes.cpp
+)
+
+juce_generate_juce_header(diy_av_ui_cpp)
+
+# Link basic GUI modules for now
+target_link_libraries(diy_av_ui_cpp
+    PRIVATE
+        juce::juce_gui_basics
+        juce::juce_gui_extra
+)

--- a/src/cpp_ui/CollapsibleBox.cpp
+++ b/src/cpp_ui/CollapsibleBox.cpp
@@ -1,0 +1,7 @@
+// Placeholder for CollapsibleBox C++ implementation.
+// Translated from src/audio/ui/collapsible_box.py
+
+#include <juce_gui_basics/juce_gui_basics.h>
+
+// TODO: Implement CollapsibleBox class using JUCE components.
+

--- a/src/cpp_ui/DefaultVoiceDialog.cpp
+++ b/src/cpp_ui/DefaultVoiceDialog.cpp
@@ -1,0 +1,7 @@
+// Placeholder for DefaultVoiceDialog C++ implementation.
+// Translated from src/audio/ui/default_voice_dialog.py
+
+#include <juce_gui_basics/juce_gui_basics.h>
+
+// TODO: Implement DefaultVoiceDialog class using JUCE components.
+

--- a/src/cpp_ui/FrequencyTesterDialog.cpp
+++ b/src/cpp_ui/FrequencyTesterDialog.cpp
@@ -1,0 +1,7 @@
+// Placeholder for FrequencyTesterDialog C++ implementation.
+// Translated from src/audio/ui/frequency_tester_dialog.py
+
+#include <juce_gui_basics/juce_gui_basics.h>
+
+// TODO: Implement FrequencyTesterDialog class using JUCE components.
+

--- a/src/cpp_ui/NoiseGeneratorDialog.cpp
+++ b/src/cpp_ui/NoiseGeneratorDialog.cpp
@@ -1,0 +1,7 @@
+// Placeholder for NoiseGeneratorDialog C++ implementation.
+// Translated from src/audio/ui/noise_generator_dialog.py
+
+#include <juce_gui_basics/juce_gui_basics.h>
+
+// TODO: Implement NoiseGeneratorDialog class using JUCE components.
+

--- a/src/cpp_ui/OverlayClipDialog.cpp
+++ b/src/cpp_ui/OverlayClipDialog.cpp
@@ -1,0 +1,7 @@
+// Placeholder for OverlayClipDialog C++ implementation.
+// Translated from src/audio/ui/overlay_clip_dialog.py
+
+#include <juce_gui_basics/juce_gui_basics.h>
+
+// TODO: Implement OverlayClipDialog class using JUCE components.
+

--- a/src/cpp_ui/PreferencesDialog.cpp
+++ b/src/cpp_ui/PreferencesDialog.cpp
@@ -1,0 +1,7 @@
+// Placeholder for PreferencesDialog C++ implementation.
+// Translated from src/audio/ui/preferences_dialog.py
+
+#include <juce_gui_basics/juce_gui_basics.h>
+
+// TODO: Implement PreferencesDialog class using JUCE components.
+

--- a/src/cpp_ui/Simulator.cpp
+++ b/src/cpp_ui/Simulator.cpp
@@ -1,0 +1,7 @@
+// Placeholder for SimulatorWindow and LEDDisplay C++ implementation.
+// Translated from src/ui/simulator.py
+
+#include <juce_gui_basics/juce_gui_basics.h>
+
+// TODO: Implement SimulatorWindow class using JUCE components.
+

--- a/src/cpp_ui/StepConfigPanel.cpp
+++ b/src/cpp_ui/StepConfigPanel.cpp
@@ -1,0 +1,7 @@
+// Placeholder for StepConfigPanel C++ implementation.
+// Translated from src/ui/step_config_panel.py
+
+#include <juce_gui_basics/juce_gui_basics.h>
+
+// TODO: Implement StepConfigPanel class using JUCE components.
+

--- a/src/cpp_ui/StepListPanel.cpp
+++ b/src/cpp_ui/StepListPanel.cpp
@@ -1,0 +1,7 @@
+// Placeholder for StepListPanel C++ implementation.
+// Translated from src/ui/step_list_panel.py
+
+#include <juce_gui_basics/juce_gui_basics.h>
+
+// TODO: Implement StepListPanel class using JUCE components.
+

--- a/src/cpp_ui/SubliminalDialog.cpp
+++ b/src/cpp_ui/SubliminalDialog.cpp
@@ -1,0 +1,7 @@
+// Placeholder for SubliminalDialog C++ implementation.
+// Translated from src/audio/ui/subliminal_dialog.py
+
+#include <juce_gui_basics/juce_gui_basics.h>
+
+// TODO: Implement SubliminalDialog class using JUCE components.
+

--- a/src/cpp_ui/Themes.cpp
+++ b/src/cpp_ui/Themes.cpp
@@ -1,0 +1,7 @@
+// Placeholder for Theme definitions C++ implementation.
+// Translated from src/audio/ui/themes.py
+
+#include <juce_gui_basics/juce_gui_basics.h>
+
+// TODO: Implement Theme struct and theme loading.
+

--- a/src/cpp_ui/VoiceEditorDialog.cpp
+++ b/src/cpp_ui/VoiceEditorDialog.cpp
@@ -1,0 +1,7 @@
+// Placeholder for VoiceEditorDialog C++ implementation.
+// Translated from src/audio/ui/voice_editor_dialog.py
+
+#include <juce_gui_basics/juce_gui_basics.h>
+
+// TODO: Implement VoiceEditorDialog class using JUCE components.
+


### PR DESCRIPTION
## Summary
- create `src/cpp_ui` with placeholder files for all current Python UI classes
- add a `CMakeLists.txt` for the new UI folder
- update top-level `CMakeLists.txt` to include the UI folder

## Testing
- `python3 -m pip install -r requirements.txt`
- `cmake -S . -B build` *(fails: Could not find JUCE)*

------
https://chatgpt.com/codex/tasks/task_e_685b399c4034832da76ee5325cb91519