### PR TITLE
Add JUCE GUI application skeleton

### DIFF
--- a/src/cpp_ui/CMakeLists.txt
+++ b/src/cpp_ui/CMakeLists.txt
@@ -9,6 +9,7 @@ juce_add_gui_app(diy_av_ui_cpp
     BUNDLE_ID com.example.diyavcpp.ui
     VERSION 0.1
     SOURCES
+        main.cpp
         Simulator.cpp
         StepConfigPanel.cpp
         StepListPanel.cpp

--- a/src/cpp_ui/main.cpp
+++ b/src/cpp_ui/main.cpp
@@ -1,0 +1,68 @@
+#include <juce_gui_basics/juce_gui_basics.h>
+#include <juce_gui_extra/juce_gui_extra.h>
+
+using namespace juce;
+
+// Forward declarations for UI components that will be implemented later.
+class StepListPanel;
+class StepConfigPanel;
+
+class MainComponent : public Component
+{
+public:
+    MainComponent()
+    {
+        setSize (800, 600);
+        // TODO: create and add child components once implemented
+    }
+
+    void resized() override
+    {
+        // TODO: layout child components
+    }
+};
+
+class MainWindow : public DocumentWindow
+{
+public:
+    MainWindow() : DocumentWindow ("DIY AV Editor",
+                                   Colours::lightgrey,
+                                   DocumentWindow::allButtons)
+    {
+        setUsingNativeTitleBar (true);
+        setContentOwned (new MainComponent(), true);
+        centreWithSize (getWidth(), getHeight());
+        setVisible (true);
+    }
+
+    void closeButtonPressed() override
+    {
+        JUCEApplication::getInstance()->systemRequestedQuit();
+    }
+};
+
+class DiyAvApplication : public JUCEApplication
+{
+public:
+    DiyAvApplication() = default;
+
+    const String getApplicationName() override       { return "DIY AV UI CPP"; }
+    const String getApplicationVersion() override    { return "0.1"; }
+    bool moreThanOneInstanceAllowed() override       { return true; }
+
+    void initialise (const String&) override
+    {
+        mainWindow.reset (new MainWindow());
+    }
+
+    void shutdown() override
+    {
+        mainWindow = nullptr;
+    }
+
+private:
+    std::unique_ptr<MainWindow> mainWindow;
+};
+
+START_JUCE_APPLICATION (DiyAvApplication)
+


### PR DESCRIPTION
## Summary
- create `main.cpp` in `src/cpp_ui` as the entry point for the JUCE UI
- register the new source in `src/cpp_ui/CMakeLists.txt`

This sets up a JUCE `JUCEApplication` with a basic `MainWindow` and `MainComponent` so additional UI components can be implemented later.

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685b3ca08e50832d8c0dc253b5a325d5