### PR TITLE
Fix missing array include

### DIFF
--- a/src/cpp_audio/Common.cpp
+++ b/src/cpp_audio/Common.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <numeric>
 #include <random>
+#include <array>
 
 std::vector<double> sineWave(double freq, const std::vector<double>& t, double phase)
 {


### PR DESCRIPTION
## Summary
- include `<array>` in `Common.cpp`

## Testing
- `g++ -std=c++17 -I./src/cpp_audio -c src/cpp_audio/Common.cpp -o /tmp/common.o`
- `cmake ..` *(fails: Could not find JUCE package)*

------
https://chatgpt.com/codex/tasks/task_e_685b604f6190832dadeb109e67621366