### PR TITLE
Add background noise and clip mixing to C++ audio

### DIFF
--- a/src/cpp_audio/Track.h
+++ b/src/cpp_audio/Track.h
@@ -27,9 +27,34 @@ struct GlobalSettings
     juce::String crossfadeCurve { "linear" };
 };
 
+struct BackgroundNoise
+{
+    juce::String filePath;
+    double amp { 0.0 };
+    double pan { 0.0 };
+    double startTime { 0.0 };
+    double fadeIn { 0.0 };
+    double fadeOut { 0.0 };
+    std::vector<std::pair<double, double>> ampEnvelope;
+};
+
+struct Clip
+{
+    juce::String filePath;
+    juce::String description;
+    double start { 0.0 };
+    double duration { 0.0 };
+    double amp { 1.0 };
+    double pan { 0.0 };
+    double fadeIn { 0.0 };
+    double fadeOut { 0.0 };
+};
+
 struct Track
 {
     GlobalSettings settings;
+    BackgroundNoise backgroundNoise;
+    std::vector<Clip> clips;
     std::vector<Step> steps;
 };
 


### PR DESCRIPTION
## Summary
- extend Track model with `backgroundNoise` and `clips`
- parse `background_noise` and `clips` from JSON
- load audio files and mix background noise and overlay clips during track assembly

## Testing
- `cmake -B build` *(fails: Could not find JUCE package)*

------
https://chatgpt.com/codex/tasks/task_e_685b70ce9684832d912c9369cfe636d7