### PR TITLE
Add JUCE step preview component

### DIFF
--- a/README_Audio.md
+++ b/README_Audio.md
@@ -75,3 +75,5 @@ steps can still be heard in full.
 
 ## C++ Port
 A minimal C++ implementation using JUCE lives in `src/cpp_audio`. Build it with CMake and ensure JUCE is available on your system.
+
+The JUCE port now provides a `StepPreviewComponent` that mirrors the Python UI's play/pause/stop controls and time slider for auditioning a single step.

--- a/src/cpp_audio/BufferAudioSource.h
+++ b/src/cpp_audio/BufferAudioSource.h
@@ -1,0 +1,63 @@
+#pragma once
+#include <juce_audio_basics/juce_audio_basics.h>
+
+class BufferAudioSource : public juce::PositionableAudioSource
+{
+public:
+    BufferAudioSource() = default;
+
+    void setBuffer(juce::AudioBuffer<float> newBuffer)
+    {
+        buffer = std::move(newBuffer);
+        position = 0;
+    }
+
+    void prepareToPlay(int /*samplesPerBlockExpected*/, double /*sr*/) override
+    {
+        position = 0;
+    }
+
+    void releaseResources() override {}
+
+    void getNextAudioBlock(const juce::AudioSourceChannelInfo& info) override
+    {
+        if (buffer.getNumSamples() == 0)
+        {
+            info.clearActiveBufferRegion();
+            return;
+        }
+
+        int remaining = buffer.getNumSamples() - position;
+        int toCopy = std::min(remaining, info.numSamples);
+
+        for (int ch = 0; ch < info.buffer->getNumChannels(); ++ch)
+            info.buffer->copyFrom(ch, info.startSample, buffer, ch % buffer.getNumChannels(), position, toCopy);
+
+        if (toCopy < info.numSamples)
+        {
+            int left = info.numSamples - toCopy;
+            for (int ch = 0; ch < info.buffer->getNumChannels(); ++ch)
+                info.buffer->copyFrom(ch, info.startSample + toCopy, buffer, ch % buffer.getNumChannels(), 0, left);
+            position = left;
+        }
+        else
+        {
+            position += toCopy;
+            if (looping && position >= buffer.getNumSamples())
+                position = 0;
+        }
+    }
+
+    void setNextReadPosition(juce::int64 newPosition) override { position = (int)newPosition; }
+    juce::int64 getNextReadPosition() const override { return position; }
+    juce::int64 getTotalLength() const override { return buffer.getNumSamples(); }
+    bool isLooping() const override { return looping; }
+    void setLooping(bool shouldLoop) override { looping = shouldLoop; }
+    bool isReady() const override { return buffer.getNumSamples() > 0; }
+
+private:
+    juce::AudioBuffer<float> buffer;
+    int position = 0;
+    bool looping = false;
+};
+

--- a/src/cpp_audio/CMakeLists.txt
+++ b/src/cpp_audio/CMakeLists.txt
@@ -32,6 +32,9 @@ juce_add_console_app(diy_av_audio_cpp
         Common.cpp
         AudioUtils.h
         AudioUtils.cpp
+        BufferAudioSource.h
+        StepPreviewer.h
+        StepPreviewer.cpp
 )
 
 juce_generate_juce_header(diy_av_audio_cpp)

--- a/src/cpp_audio/StepPreviewer.cpp
+++ b/src/cpp_audio/StepPreviewer.cpp
@@ -1,0 +1,98 @@
+#include "StepPreviewer.h"
+
+StepPreviewer::StepPreviewer(juce::AudioDeviceManager& dm)
+    : deviceManager(dm)
+{
+    player = std::make_unique<juce::AudioSourcePlayer>();
+    player->setSource(&transport);
+}
+
+bool StepPreviewer::loadStep(const Step& step, const GlobalSettings& settings, double previewDuration)
+{
+    sampleRate = settings.sampleRate;
+    auto audio = generateAudio(step, settings, previewDuration);
+    bufferSource = std::make_unique<BufferAudioSource>();
+    bufferSource->setBuffer(std::move(audio));
+    transport.setSource(bufferSource.get(), 0, nullptr, sampleRate);
+    lengthSeconds = transport.getLengthInSeconds();
+    transport.setPosition(0.0);
+    return bufferSource->getTotalLength() > 0;
+}
+
+void StepPreviewer::play()
+{
+    if (playing)
+        return;
+    deviceManager.addAudioCallback(player.get());
+    transport.start();
+    playing = true;
+}
+
+void StepPreviewer::pause()
+{
+    if (!playing)
+        return;
+    transport.stop();
+    deviceManager.removeAudioCallback(player.get());
+    playing = false;
+}
+
+void StepPreviewer::stop()
+{
+    transport.stop();
+    transport.setPosition(0.0);
+    if (playing)
+    {
+        deviceManager.removeAudioCallback(player.get());
+        playing = false;
+    }
+}
+
+void StepPreviewer::setPosition(double seconds)
+{
+    transport.setPosition(seconds);
+}
+
+double StepPreviewer::getPosition() const
+{
+    return transport.getCurrentPosition();
+}
+
+double StepPreviewer::getLength() const
+{
+    return lengthSeconds;
+}
+
+bool StepPreviewer::isPlaying() const
+{
+    return playing;
+}
+
+juce::AudioBuffer<float> StepPreviewer::generateAudio(const Step& step, const GlobalSettings& settings, double previewDuration)
+{
+    Track t;
+    t.settings = settings;
+    t.settings.crossfadeDuration = 0.0; // no crossfade
+    t.steps.push_back(step);
+
+    auto stepBuffer = assembleTrack(t);
+
+    int previewSamples = static_cast<int>(previewDuration * settings.sampleRate);
+    juce::AudioBuffer<float> result(2, std::max(0, previewSamples));
+    result.clear();
+
+    if (stepBuffer.getNumSamples() == 0 || previewSamples <= 0)
+        return result;
+
+    int pos = 0;
+    while (pos < previewSamples)
+    {
+        int remain = previewSamples - pos;
+        int copy = std::min(remain, stepBuffer.getNumSamples());
+        for (int ch = 0; ch < 2; ++ch)
+            result.copyFrom(ch, pos, stepBuffer, ch, 0, copy);
+        pos += copy;
+    }
+    return result;
+}
+

--- a/src/cpp_audio/StepPreviewer.h
+++ b/src/cpp_audio/StepPreviewer.h
@@ -1,0 +1,33 @@
+#pragma once
+#include "Track.h"
+#include "BufferAudioSource.h"
+#include <juce_audio_utils/juce_audio_utils.h>
+
+class StepPreviewer
+{
+public:
+    explicit StepPreviewer(juce::AudioDeviceManager& dm);
+
+    bool loadStep(const Step& step, const GlobalSettings& settings, double previewDuration);
+
+    void play();
+    void pause();
+    void stop();
+
+    void setPosition(double seconds);
+    double getPosition() const;
+    double getLength() const;
+    bool isPlaying() const;
+
+private:
+    juce::AudioBuffer<float> generateAudio(const Step& step, const GlobalSettings& settings, double previewDuration);
+
+    juce::AudioDeviceManager& deviceManager;
+    std::unique_ptr<juce::AudioSourcePlayer> player;
+    juce::AudioTransportSource transport;
+    std::unique_ptr<BufferAudioSource> bufferSource;
+    double sampleRate = 44100.0;
+    double lengthSeconds = 0.0;
+    bool playing = false;
+};
+

--- a/src/cpp_ui/CMakeLists.txt
+++ b/src/cpp_ui/CMakeLists.txt
@@ -22,6 +22,8 @@ juce_add_gui_app(diy_av_ui_cpp
         SubliminalDialog.cpp
         VoiceEditorDialog.cpp
         Themes.cpp
+        StepPreviewComponent.h
+        StepPreviewComponent.cpp
 )
 
 juce_generate_juce_header(diy_av_ui_cpp)

--- a/src/cpp_ui/StepPreviewComponent.cpp
+++ b/src/cpp_ui/StepPreviewComponent.cpp
@@ -1,0 +1,84 @@
+#include "StepPreviewComponent.h"
+
+StepPreviewComponent::StepPreviewComponent(juce::AudioDeviceManager& dm)
+    : previewer(dm)
+{
+    addAndMakeVisible(playPauseButton);
+    playPauseButton.addListener(this);
+
+    addAndMakeVisible(stopButton);
+    stopButton.addListener(this);
+
+    addAndMakeVisible(positionSlider);
+    positionSlider.setSliderStyle(juce::Slider::LinearHorizontal);
+    positionSlider.addListener(this);
+
+    addAndMakeVisible(timeLabel);
+    timeLabel.setJustificationType(juce::Justification::centred);
+}
+
+void StepPreviewComponent::loadStep(const Step& step, const GlobalSettings& settings, double previewDuration)
+{
+    previewer.loadStep(step, settings, previewDuration);
+    positionSlider.setRange(0.0, previewer.getLength(), 0.001);
+    positionSlider.setValue(0.0);
+    updateTimeLabel();
+}
+
+void StepPreviewComponent::resized()
+{
+    auto area = getLocalBounds().reduced(4);
+    auto top = area.removeFromTop(24);
+    playPauseButton.setBounds(top.removeFromLeft(60));
+    stopButton.setBounds(top.removeFromLeft(60));
+    timeLabel.setBounds(top);
+    area.removeFromTop(4);
+    positionSlider.setBounds(area);
+}
+
+void StepPreviewComponent::buttonClicked(juce::Button* b)
+{
+    if (b == &playPauseButton)
+    {
+        if (previewer.isPlaying())
+        {
+            previewer.pause();
+            playPauseButton.setButtonText("Play");
+        }
+        else
+        {
+            previewer.play();
+            playPauseButton.setButtonText("Pause");
+            startTimerHz(30);
+        }
+    }
+    else if (b == &stopButton)
+    {
+        previewer.stop();
+        playPauseButton.setButtonText("Play");
+        positionSlider.setValue(0.0);
+        updateTimeLabel();
+    }
+}
+
+void StepPreviewComponent::sliderValueChanged(juce::Slider* s)
+{
+    if (s == &positionSlider && ! s->isMouseButtonDown())
+        previewer.setPosition(s->getValue());
+}
+
+void StepPreviewComponent::timerCallback()
+{
+    positionSlider.setValue(previewer.getPosition(), juce::dontSendNotification);
+    updateTimeLabel();
+    if (! previewer.isPlaying())
+        stopTimer();
+}
+
+void StepPreviewComponent::updateTimeLabel()
+{
+    auto pos = previewer.getPosition();
+    auto len = previewer.getLength();
+    timeLabel.setText(juce::String(pos, 1) + " / " + juce::String(len, 1), juce::dontSendNotification);
+}
+

--- a/src/cpp_ui/StepPreviewComponent.h
+++ b/src/cpp_ui/StepPreviewComponent.h
@@ -1,0 +1,28 @@
+#pragma once
+#include <juce_gui_basics/juce_gui_basics.h>
+#include "../cpp_audio/StepPreviewer.h"
+
+class StepPreviewComponent : public juce::Component,
+                              private juce::Button::Listener,
+                              private juce::Slider::Listener,
+                              private juce::Timer
+{
+public:
+    explicit StepPreviewComponent(juce::AudioDeviceManager& dm);
+
+    void loadStep(const Step& step, const GlobalSettings& settings, double previewDuration);
+    void resized() override;
+
+private:
+    void buttonClicked(juce::Button*) override;
+    void sliderValueChanged(juce::Slider*) override;
+    void timerCallback() override;
+    void updateTimeLabel();
+
+    StepPreviewer previewer;
+    juce::TextButton playPauseButton {"Play"};
+    juce::TextButton stopButton {"Stop"};
+    juce::Slider positionSlider;
+    juce::Label timeLabel;
+};
+


### PR DESCRIPTION
## Summary
- implement `BufferAudioSource` and `StepPreviewer` for playing a single step
- add `StepPreviewComponent` UI with play/pause/stop buttons and slider
- hook new sources into CMake builds
- document the new JUCE component in the audio README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685b70dda450832d8d8b8abde09c51fe