### PR TITLE
Add preset file support and sync synth map

### DIFF
--- a/src/cpp_audio/CMakeLists.txt
+++ b/src/cpp_audio/CMakeLists.txt
@@ -24,6 +24,10 @@ juce_add_console_app(diy_av_audio_cpp
         synths/SpatialAngleModulation.cpp
         synths/NoiseFlanger.cpp
         synths/Subliminals.cpp
+        presets/VoicePreset.h
+        presets/VoicePreset.cpp
+        presets/NoiseParams.h
+        presets/NoiseParams.cpp
         models/StepModel.h
         models/StepModel.cpp
         models/VoiceModel.h

--- a/src/cpp_audio/Track.cpp
+++ b/src/cpp_audio/Track.cpp
@@ -11,6 +11,7 @@ static std::map<juce::String, SynthFunc> synthMap{
     { "binaural_beat", binauralBeat },
     { "binaural_beat_transition", binauralBeatTransition },
     { "isochronic_tone", isochronicTone },
+    { "isochronic_tone_transition", isochronicToneTransition },
     { "rhythmic_waveshaping", rhythmicWaveshaping },
     { "rhythmic_waveshaping_transition", rhythmicWaveshapingTransition },
     { "stereo_am_independent", stereoAMIndependent },

--- a/src/cpp_audio/presets/NoiseParams.cpp
+++ b/src/cpp_audio/presets/NoiseParams.cpp
@@ -1,0 +1,69 @@
+#include "NoiseParams.h"
+
+using namespace juce;
+
+bool saveNoiseParams(const NoiseParams& params, const File& file)
+{
+    File target = file;
+    if (target.getFileExtension() != NOISE_FILE_EXTENSION)
+        target = target.withFileExtension(NOISE_FILE_EXTENSION);
+
+    auto* obj = new DynamicObject();
+    obj->setProperty("duration_seconds", params.durationSeconds);
+    obj->setProperty("sample_rate", params.sampleRate);
+    obj->setProperty("noise_type", params.noiseType);
+    obj->setProperty("lfo_waveform", params.lfoWaveform);
+    obj->setProperty("transition", params.transition);
+    obj->setProperty("lfo_freq", params.lfoFreq);
+    obj->setProperty("start_lfo_freq", params.startLfoFreq);
+    obj->setProperty("end_lfo_freq", params.endLfoFreq);
+    obj->setProperty("sweeps", params.sweeps);
+    obj->setProperty("start_lfo_phase_offset_deg", params.startLfoPhaseOffsetDeg);
+    obj->setProperty("end_lfo_phase_offset_deg", params.endLfoPhaseOffsetDeg);
+    obj->setProperty("start_intra_phase_offset_deg", params.startIntraPhaseOffsetDeg);
+    obj->setProperty("end_intra_phase_offset_deg", params.endIntraPhaseOffsetDeg);
+    obj->setProperty("initial_offset", params.initialOffset);
+    obj->setProperty("post_offset", params.postOffset);
+    obj->setProperty("input_audio_path", params.inputAudioPath);
+    obj->setProperty("start_time", params.startTime);
+    obj->setProperty("fade_in", params.fadeIn);
+    obj->setProperty("fade_out", params.fadeOut);
+    obj->setProperty("amp_envelope", params.ampEnvelope);
+
+    var root(obj);
+    String json = JSON::toString(root, true);
+    return target.replaceWithText(json);
+}
+
+NoiseParams loadNoiseParams(const File& file)
+{
+    NoiseParams params;
+    if (!file.existsAsFile())
+        return params;
+
+    var root = JSON::parse(file.loadFileAsString());
+    if (auto* obj = root.getDynamicObject())
+    {
+        params.durationSeconds = obj->getProperty("duration_seconds", params.durationSeconds);
+        params.sampleRate = obj->getProperty("sample_rate", params.sampleRate);
+        params.noiseType = obj->getProperty("noise_type", params.noiseType).toString();
+        params.lfoWaveform = obj->getProperty("lfo_waveform", params.lfoWaveform).toString();
+        params.transition = obj->getProperty("transition", params.transition);
+        params.lfoFreq = obj->getProperty("lfo_freq", params.lfoFreq);
+        params.startLfoFreq = obj->getProperty("start_lfo_freq", params.startLfoFreq);
+        params.endLfoFreq = obj->getProperty("end_lfo_freq", params.endLfoFreq);
+        params.sweeps = obj->getProperty("sweeps");
+        params.startLfoPhaseOffsetDeg = obj->getProperty("start_lfo_phase_offset_deg", params.startLfoPhaseOffsetDeg);
+        params.endLfoPhaseOffsetDeg = obj->getProperty("end_lfo_phase_offset_deg", params.endLfoPhaseOffsetDeg);
+        params.startIntraPhaseOffsetDeg = obj->getProperty("start_intra_phase_offset_deg", params.startIntraPhaseOffsetDeg);
+        params.endIntraPhaseOffsetDeg = obj->getProperty("end_intra_phase_offset_deg", params.endIntraPhaseOffsetDeg);
+        params.initialOffset = obj->getProperty("initial_offset", params.initialOffset);
+        params.postOffset = obj->getProperty("post_offset", params.postOffset);
+        params.inputAudioPath = obj->getProperty("input_audio_path", params.inputAudioPath).toString();
+        params.startTime = obj->getProperty("start_time", params.startTime);
+        params.fadeIn = obj->getProperty("fade_in", params.fadeIn);
+        params.fadeOut = obj->getProperty("fade_out", params.fadeOut);
+        params.ampEnvelope = obj->getProperty("amp_envelope");
+    }
+    return params;
+}

--- a/src/cpp_audio/presets/NoiseParams.h
+++ b/src/cpp_audio/presets/NoiseParams.h
@@ -1,0 +1,31 @@
+#pragma once
+#include <juce_core/juce_core.h>
+
+constexpr const char* NOISE_FILE_EXTENSION = ".noise";
+
+struct NoiseParams
+{
+    double durationSeconds{60.0};
+    int sampleRate{44100};
+    juce::String noiseType{"pink"};
+    juce::String lfoWaveform{"sine"};
+    bool transition{false};
+    double lfoFreq{1.0 / 12.0};
+    double startLfoFreq{1.0 / 12.0};
+    double endLfoFreq{1.0 / 12.0};
+    juce::var sweeps; // array of sweeps
+    int startLfoPhaseOffsetDeg{0};
+    int endLfoPhaseOffsetDeg{0};
+    int startIntraPhaseOffsetDeg{0};
+    int endIntraPhaseOffsetDeg{0};
+    double initialOffset{0.0};
+    double postOffset{0.0};
+    juce::String inputAudioPath;
+    double startTime{0.0};
+    double fadeIn{0.0};
+    double fadeOut{0.0};
+    juce::var ampEnvelope; // array of envelope points
+};
+
+bool saveNoiseParams(const NoiseParams& params, const juce::File& file);
+NoiseParams loadNoiseParams(const juce::File& file);

--- a/src/cpp_audio/presets/VoicePreset.cpp
+++ b/src/cpp_audio/presets/VoicePreset.cpp
@@ -1,0 +1,59 @@
+#include "VoicePreset.h"
+
+using namespace juce;
+
+static var namedValueSetToVar(const NamedValueSet& set)
+{
+    auto* obj = new DynamicObject();
+    for (const auto& p : set)
+        obj->setProperty(p.name, p.value);
+    return var(obj);
+}
+
+static NamedValueSet varToNamedValueSet(const var& v)
+{
+    NamedValueSet set;
+    if (auto* obj = v.getDynamicObject())
+    {
+        for (const auto& p : obj->getProperties())
+            set.set(p.name, p.value);
+    }
+    return set;
+}
+
+bool saveVoicePreset(const VoicePreset& preset, const File& file)
+{
+    File target = file;
+    if (target.getFileExtension() != VOICE_FILE_EXTENSION)
+        target = target.withFileExtension(VOICE_FILE_EXTENSION);
+
+    auto* obj = new DynamicObject();
+    obj->setProperty("synth_function_name", preset.synthFunctionName);
+    obj->setProperty("is_transition", preset.isTransition);
+    obj->setProperty("params", namedValueSetToVar(preset.params));
+    if (!preset.volumeEnvelope.isVoid())
+        obj->setProperty("volume_envelope", preset.volumeEnvelope);
+    obj->setProperty("description", preset.description);
+
+    var root(obj);
+    String json = JSON::toString(root, true);
+    return target.replaceWithText(json);
+}
+
+VoicePreset loadVoicePreset(const File& file)
+{
+    VoicePreset preset;
+    if (!file.existsAsFile())
+        return preset;
+
+    var root = JSON::parse(file.loadFileAsString());
+    if (auto* obj = root.getDynamicObject())
+    {
+        preset.synthFunctionName = obj->getProperty("synth_function_name").toString();
+        preset.isTransition = obj->getProperty("is_transition");
+        preset.params = varToNamedValueSet(obj->getProperty("params"));
+        preset.volumeEnvelope = obj->getProperty("volume_envelope");
+        preset.description = obj->getProperty("description").toString();
+    }
+    return preset;
+}

--- a/src/cpp_audio/presets/VoicePreset.h
+++ b/src/cpp_audio/presets/VoicePreset.h
@@ -1,0 +1,16 @@
+#pragma once
+#include <juce_core/juce_core.h>
+
+constexpr const char* VOICE_FILE_EXTENSION = ".voice";
+
+struct VoicePreset
+{
+    juce::String synthFunctionName;
+    bool isTransition{false};
+    juce::NamedValueSet params;
+    juce::var volumeEnvelope; // may be undefined
+    juce::String description;
+};
+
+bool saveVoicePreset(const VoicePreset& preset, const juce::File& file);
+VoicePreset loadVoicePreset(const juce::File& file);


### PR DESCRIPTION
## Summary
- add C++ VoicePreset/NoiseParams structs with save/load helpers
- include preset files in build system
- expose isochronic_tone_transition in the synth map

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b70f54e94832da560f2e8c5d9d5e7