### PR TITLE
Implement external step loading in C++ audio

### DIFF
--- a/README_Audio.md
+++ b/README_Audio.md
@@ -77,3 +77,5 @@ steps can still be heard in full.
 A minimal C++ implementation using JUCE lives in `src/cpp_audio`. Build it with CMake and ensure JUCE is available on your system.
 
 The JUCE port now provides a `StepPreviewComponent` that mirrors the Python UI's play/pause/stop controls and time slider for auditioning a single step.
+
+An additional helper `loadExternalStepsFromJson` can append steps from another JSON file to an existing `Track`. The JSON must contain a top-level `steps` list, mirroring the "Load External Step" action in the Python editor.

--- a/src/cpp_audio/Track.h
+++ b/src/cpp_audio/Track.h
@@ -61,4 +61,8 @@ struct Track
 Track loadTrackFromJson(const juce::File& file);
 bool writeWavFile(const juce::File& file, const juce::AudioBuffer<float>& buffer, double sampleRate);
 juce::AudioBuffer<float> assembleTrack(const Track& track);
+/** Loads steps from a JSON file containing a top-level "steps" array and
+    appends them to the provided vector.
+    @return number of steps successfully loaded. */
+int loadExternalStepsFromJson(const juce::File& file, std::vector<Step>& steps);
 


### PR DESCRIPTION
## Summary
- support external step JSON files
- document new helper in README_Audio

## Testing
- `cmake --preset=default` *(fails: JUCE not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b7b443b50832da5f4212363de3141