### PR TITLE
Add reset function to StepPreviewComponent

### DIFF
--- a/README_Audio.md
+++ b/README_Audio.md
@@ -76,4 +76,4 @@ steps can still be heard in full.
 ## C++ Port
 A minimal C++ implementation using JUCE lives in `src/cpp_audio`. Build it with CMake and ensure JUCE is available on your system.
 
-The JUCE port now provides a `StepPreviewComponent` that mirrors the Python UI's play/pause/stop controls and time slider for auditioning a single step.
+The JUCE port now provides a `StepPreviewComponent` that mirrors the Python UI's play/pause/stop controls and time slider for auditioning a single step. It also includes a **Reset** button and labels the currently loaded step alongside the playback time.

--- a/src/cpp_ui/StepPreviewComponent.h
+++ b/src/cpp_ui/StepPreviewComponent.h
@@ -11,6 +11,7 @@ public:
     explicit StepPreviewComponent(juce::AudioDeviceManager& dm);
 
     void loadStep(const Step& step, const GlobalSettings& settings, double previewDuration);
+    void reset();
     void resized() override;
 
 private:
@@ -18,11 +19,15 @@ private:
     void sliderValueChanged(juce::Slider*) override;
     void timerCallback() override;
     void updateTimeLabel();
+    static juce::String formatTime(double seconds);
 
     StepPreviewer previewer;
     juce::TextButton playPauseButton {"Play"};
     juce::TextButton stopButton {"Stop"};
+    juce::TextButton resetButton {"Reset"};
     juce::Slider positionSlider;
     juce::Label timeLabel;
+    juce::Label stepLabel;
+    juce::String loadedStepName;
 };
 


### PR DESCRIPTION
## Summary
- expand `StepPreviewComponent` with reset button and step label
- display human friendly playback times
- mention reset button in README

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685b7b958100832d8ea5169f3a607721