### PR TITLE
Add C++ UI hooks for noise generator & frequency tester

### DIFF
--- a/src/cpp_ui/FrequencyTesterDialog.cpp
+++ b/src/cpp_ui/FrequencyTesterDialog.cpp
@@ -272,4 +272,9 @@ private:
     }
 };
 
+std::unique_ptr<juce::Component> createFrequencyTesterDialog(juce::AudioDeviceManager& dm)
+{
+    return std::make_unique<FrequencyTesterDialog>(dm, nullptr);
+}
+
 

--- a/src/cpp_ui/FrequencyTesterDialog.h
+++ b/src/cpp_ui/FrequencyTesterDialog.h
@@ -1,0 +1,8 @@
+
+#ifndef DIY_AV_UI_FREQUENCY_TESTER_DIALOG_H
+#define DIY_AV_UI_FREQUENCY_TESTER_DIALOG_H
+#include <memory>
+#include <juce_gui_basics/juce_gui_basics.h>
+#include <juce_audio_devices/juce_audio_devices.h>
+std::unique_ptr<juce::Component> createFrequencyTesterDialog(juce::AudioDeviceManager&);
+#endif

--- a/src/cpp_ui/NoiseGeneratorDialog.cpp
+++ b/src/cpp_ui/NoiseGeneratorDialog.cpp
@@ -505,4 +505,9 @@ private:
     }
 };
 
+std::unique_ptr<juce::Component> createNoiseGeneratorDialog()
+{
+    return std::make_unique<NoiseGeneratorDialog>();
+}
+
 

--- a/src/cpp_ui/NoiseGeneratorDialog.h
+++ b/src/cpp_ui/NoiseGeneratorDialog.h
@@ -1,0 +1,7 @@
+
+#ifndef DIY_AV_UI_NOISE_GENERATOR_DIALOG_H
+#define DIY_AV_UI_NOISE_GENERATOR_DIALOG_H
+#include <memory>
+#include <juce_gui_basics/juce_gui_basics.h>
+std::unique_ptr<juce::Component> createNoiseGeneratorDialog();
+#endif

--- a/src/cpp_ui/main.cpp
+++ b/src/cpp_ui/main.cpp
@@ -1,5 +1,7 @@
 #include <juce_gui_basics/juce_gui_basics.h>
 #include <juce_gui_extra/juce_gui_extra.h>
+#include "NoiseGeneratorDialog.h"
+#include "FrequencyTesterDialog.h"
 
 using namespace juce;
 
@@ -7,18 +9,61 @@ using namespace juce;
 class StepListPanel;
 class StepConfigPanel;
 
-class MainComponent : public Component
+class MainComponent : public Component,
+                      private Button::Listener
 {
 public:
     MainComponent()
     {
         setSize (800, 600);
-        // TODO: create and add child components once implemented
+
+        deviceManager.initialise(0, 2, nullptr, true);
+
+        addAndMakeVisible(noiseButton);
+        noiseButton.setButtonText("Noise Generator");
+        noiseButton.addListener(this);
+
+        addAndMakeVisible(freqButton);
+        freqButton.setButtonText("Frequency Tester");
+        freqButton.addListener(this);
     }
 
     void resized() override
     {
-        // TODO: layout child components
+        auto area = getLocalBounds().reduced(10);
+        noiseButton.setBounds(area.removeFromTop(30));
+        area.removeFromTop(10);
+        freqButton.setBounds(area.removeFromTop(30));
+    }
+
+private:
+    TextButton noiseButton, freqButton;
+    AudioDeviceManager deviceManager;
+
+    void buttonClicked(Button* b)
+    {
+        if (b == &noiseButton)
+        {
+            DialogWindow::LaunchOptions opts;
+            opts.content = createNoiseGeneratorDialog();
+            opts.dialogTitle = "Noise Generator";
+            opts.dialogBackgroundColour = Colours::lightgrey;
+            opts.escapeKeyTriggersCloseButton = true;
+            opts.useNativeTitleBar = true;
+            opts.resizable = true;
+            opts.runModal();
+        }
+        else if (b == &freqButton)
+        {
+            DialogWindow::LaunchOptions opts;
+            opts.content = createFrequencyTesterDialog(deviceManager);
+            opts.dialogTitle = "Frequency Tester";
+            opts.dialogBackgroundColour = Colours::lightgrey;
+            opts.escapeKeyTriggersCloseButton = true;
+            opts.useNativeTitleBar = true;
+            opts.resizable = true;
+            opts.runModal();
+        }
     }
 };
 


### PR DESCRIPTION
## Summary
- add factory headers for NoiseGeneratorDialog and FrequencyTesterDialog
- expose factory functions in implementation files
- update main C++ UI to show buttons for Noise Generator and Frequency Tester

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b7c3a500c832da4704a9a5470202d