### PR TITLE
Add external steps option to CPP tool

### DIFF
--- a/README_Audio.md
+++ b/README_Audio.md
@@ -80,3 +80,9 @@ The JUCE port now provides a `StepPreviewComponent` that mirrors the Python UI's
 
 An additional helper `loadExternalStepsFromJson` can append steps from another JSON file to an existing `Track`. The JSON must contain a top-level `steps` list, mirroring the "Load External Step" action in the Python editor.
 
+The console application `diy_av_audio_cpp` now accepts an optional third argument to load such an external step file when generating audio:
+
+```bash
+diy_av_audio_cpp input.json output.wav extra_steps.json
+```
+

--- a/src/cpp_audio/main.cpp
+++ b/src/cpp_audio/main.cpp
@@ -7,15 +7,22 @@ int main (int argc, char* argv[])
 {
     juce::ConsoleApplication app (argc, argv);
 
-    if (argc < 3)
+    if (argc < 3 || argc > 4)
     {
-        juce::Logger::writeToLog("Usage: diy_av_audio_cpp <input.json> <output.wav>");
+        juce::Logger::writeToLog("Usage: diy_av_audio_cpp <input.json> <output.wav> [extra_steps.json]");
         return 1;
     }
 
     juce::File inFile(argv[1]);
     juce::File outFile(argv[2]);
     Track track = loadTrackFromJson(inFile);
+
+    if (argc == 4)
+    {
+        juce::File stepsFile(argv[3]);
+        int added = loadExternalStepsFromJson(stepsFile, track.steps);
+        juce::Logger::writeToLog(juce::String("Loaded ") + juce::String(added) + " external step(s)");
+    }
 
     double sampleRate = track.settings.sampleRate;
 


### PR DESCRIPTION
## Summary
- support optional extra steps JSON in `diy_av_audio_cpp`
- document new CLI argument in README

## Testing
- `cmake -S . -B build` *(fails: Could not find JUCE package)*

------
https://chatgpt.com/codex/tasks/task_e_685b8427414c832dacf7085de4149cc8