### PR TITLE
Add JSON save/load actions for C++ editor

### DIFF
--- a/src/cpp_audio/Track.h
+++ b/src/cpp_audio/Track.h
@@ -59,6 +59,10 @@ struct Track
 };
 
 Track loadTrackFromJson(const juce::File& file);
+/** Saves the given track structure to a JSON file. The file extension will
+    be forced to ".json" if not already present.
+    @return true on success. */
+bool saveTrackToJson(const Track& track, const juce::File& file);
 bool writeWavFile(const juce::File& file, const juce::AudioBuffer<float>& buffer, double sampleRate);
 juce::AudioBuffer<float> assembleTrack(const Track& track);
 /** Loads steps from a JSON file containing a top-level "steps" array and


### PR DESCRIPTION
## Summary
- add `saveTrackToJson` function to `Track` API
- implement JSON export in `Track.cpp`
- extend JUCE UI to create/open/save track files
- lay out overlay panel and subliminal button in `resized`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685b841a61cc832d84d30062e1d238c8