### PR TITLE
Integrate audio engine with GUI

### DIFF
--- a/src/cpp_audio/CMakeLists.txt
+++ b/src/cpp_audio/CMakeLists.txt
@@ -4,48 +4,60 @@ project(DIY_AV_Audio_CPP)
 
 find_package(JUCE CONFIG REQUIRED)
 
+set(AUDIO_SOURCES
+    Track.h
+    Track.cpp
+    SynthFunctions.h
+    synths/BinauralBeat.cpp
+    synths/IsochronicTone.cpp
+    synths/RhythmicWaveshaping.cpp
+    synths/StereoAMIndependent.cpp
+    synths/WaveShapeStereoAm.cpp
+    synths/MonauralBeatStereoAmps.cpp
+    synths/QamBeat.cpp
+    synths/HybridQamMonauralBeat.cpp
+    synths/SpatialAngleModulation.cpp
+    synths/NoiseFlanger.cpp
+    synths/Subliminals.cpp
+    presets/VoicePreset.h
+    presets/VoicePreset.cpp
+    presets/NoiseParams.h
+    presets/NoiseParams.cpp
+    models/StepModel.h
+    models/StepModel.cpp
+    models/VoiceModel.h
+    models/VoiceModel.cpp
+    Common.h
+    Common.cpp
+    AudioUtils.h
+    AudioUtils.cpp
+    BufferAudioSource.h
+    StepPreviewer.h
+    StepPreviewer.cpp
+)
+
+add_library(diy_av_audio STATIC ${AUDIO_SOURCES})
+
+target_include_directories(diy_av_audio PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
+target_link_libraries(diy_av_audio
+    PUBLIC
+        juce::juce_audio_utils
+        juce::juce_dsp
+        juce::juce_audio_formats
+)
+
 juce_add_console_app(diy_av_audio_cpp
     PRODUCT_NAME "DIY AV Audio CPP"
     BUNDLE_ID com.example.diyavcpp
     VERSION 0.1
     SOURCES
         main.cpp
-        Track.h
-        Track.cpp
-        SynthFunctions.h
-        synths/BinauralBeat.cpp
-        synths/IsochronicTone.cpp
-        synths/RhythmicWaveshaping.cpp
-        synths/StereoAMIndependent.cpp
-        synths/WaveShapeStereoAm.cpp
-        synths/MonauralBeatStereoAmps.cpp
-        synths/QamBeat.cpp
-        synths/HybridQamMonauralBeat.cpp
-        synths/SpatialAngleModulation.cpp
-        synths/NoiseFlanger.cpp
-        synths/Subliminals.cpp
-        presets/VoicePreset.h
-        presets/VoicePreset.cpp
-        presets/NoiseParams.h
-        presets/NoiseParams.cpp
-        models/StepModel.h
-        models/StepModel.cpp
-        models/VoiceModel.h
-        models/VoiceModel.cpp
-        Common.h
-        Common.cpp
-        AudioUtils.h
-        AudioUtils.cpp
-        BufferAudioSource.h
-        StepPreviewer.h
-        StepPreviewer.cpp
 )
 
 juce_generate_juce_header(diy_av_audio_cpp)
 
 target_link_libraries(diy_av_audio_cpp
     PRIVATE
-        juce::juce_audio_utils
-        juce::juce_dsp
-        juce::juce_audio_formats
+        diy_av_audio
 )

--- a/src/cpp_ui/CMakeLists.txt
+++ b/src/cpp_ui/CMakeLists.txt
@@ -35,4 +35,5 @@ target_link_libraries(diy_av_ui_cpp
     PRIVATE
         juce::juce_gui_basics
         juce::juce_gui_extra
+        diy_av_audio
 )

--- a/src/cpp_ui/main.cpp
+++ b/src/cpp_ui/main.cpp
@@ -4,6 +4,7 @@
 #include "NoiseGeneratorDialog.h"
 #include "FrequencyTesterDialog.h"
 #include "../cpp_audio/Track.h"
+#include "StepPreviewComponent.h"
 
 #include <memory>
 
@@ -69,6 +70,7 @@ public:
         // TODO: create and add child components once implemented
 
         addAndMakeVisible(overlayPanel);
+        addAndMakeVisible(stepPreview);
         addAndMakeVisible(subliminalButton);
         subliminalButton.addListener(this);
         subliminalButton.setButtonText("Add Subliminal Voice");
@@ -91,12 +93,16 @@ public:
         area.removeFromTop(10);
         freqButton.setBounds(area.removeFromTop(30));
 
-        overlayPanel.setBounds(getLocalBounds().reduced(8));
+        auto previewArea = area.removeFromBottom(110);
+        stepPreview.setBounds(previewArea.reduced(0, 4));
+
+        overlayPanel.setBounds(area.reduced(0, 4));
         subliminalButton.setBounds(10, 10, 160, 30);
     }
 
 private:
     TextButton noiseButton, freqButton;
+    StepPreviewComponent stepPreview {deviceManager};
     AudioDeviceManager deviceManager;
     Track currentTrack;
     juce::File currentFile;
@@ -144,6 +150,7 @@ private:
     {
         currentTrack = createDefaultTrack();
         currentFile = {};
+        stepPreview.reset();
     }
 
     void openTrack()
@@ -156,6 +163,10 @@ private:
             AlertWindow::showMessageBoxAsync(AlertWindow::InfoIcon,
                                             "Open",
                                             "Loaded track from\n" + currentFile.getFullPathName());
+            if (! currentTrack.steps.empty())
+                stepPreview.loadStep(currentTrack.steps.front(), currentTrack.settings, 10.0);
+            else
+                stepPreview.reset();
         }
     }
 


### PR DESCRIPTION
## Summary
- expose cpp_audio code as a static library
- link cpp_ui against the audio library
- preview the first step when a track is opened
- show audio preview controls in the main window

## Testing
- `cmake .. -DCMAKE_BUILD_TYPE=Release` *(fails: Could not find a package configuration file provided by "JUCE")*

------
https://chatgpt.com/codex/tasks/task_e_685c0b3c2910832dbe711f962fb79f93