### PR TITLE
Add Load Steps to JUCE step panel

### DIFF
--- a/README_Audio.md
+++ b/README_Audio.md
@@ -78,7 +78,7 @@ A minimal C++ implementation using JUCE lives in `src/cpp_audio`. Build it with 
 
 The JUCE port now provides a `StepPreviewComponent` that mirrors the Python UI's play/pause/stop controls and time slider for auditioning a single step. It also includes a **Reset** button and labels the currently loaded step alongside the playback time.
 
-An additional helper `loadExternalStepsFromJson` can append steps from another JSON file to an existing `Track`. The JSON must contain a top-level `steps` list, mirroring the "Load External Step" action in the Python editor.
+An additional helper `loadExternalStepsFromJson` can append steps from another JSON file to an existing `Track`. The JSON must contain a top-level `steps` list, mirroring the "Load External Step" action in the Python editor. The JUCE `StepListPanel` component now exposes a **Load Steps** button to import such files directly into the list.
 
 The console application `diy_av_audio_cpp` now accepts an optional third argument to load such an external step file when generating audio:
 


### PR DESCRIPTION
## Summary
- expose `Load Steps` button in `StepListPanel` to import JSON step files
- parse external steps via `juce::JSON` and append them
- document new button in README

## Testing
- `cmake -S . -B build` *(fails: Could not find JUCE)*

------
https://chatgpt.com/codex/tasks/task_e_685c0d68e874832db8d4ed76582800a3