### PR TITLE
Implement preferences dialog in C++ UI

### DIFF
--- a/src/cpp_ui/DefaultVoiceDialog.h
+++ b/src/cpp_ui/DefaultVoiceDialog.h
@@ -2,11 +2,7 @@
 
 #include <juce_gui_basics/juce_gui_basics.h>
 #include <juce_data_structures/juce_data_structures.h>
-
-struct Preferences
-{
-    juce::var defaultVoice; // stores DynamicObject with synth_function_name, is_transition, params, volume_envelope
-};
+#include "Preferences.h"
 
 class DefaultVoiceDialog  : public juce::DialogWindow,
                             private juce::Button::Listener

--- a/src/cpp_ui/FrequencyTesterDialog.cpp
+++ b/src/cpp_ui/FrequencyTesterDialog.cpp
@@ -5,6 +5,7 @@
 #include <juce_audio_devices/juce_audio_devices.h>
 #include <juce_dsp/juce_dsp.h>
 #include "../cpp_audio/SynthFunctions.h"
+#include "Preferences.h"
 
 using namespace juce;
 
@@ -23,11 +24,6 @@ inline double dbToAmplitude (double db)
     return db <= MIN_DB ? 0.0 : std::pow (10.0, db / 20.0);
 }
 
-struct Preferences
-{
-    int sampleRate = 44100;
-    String amplitudeDisplayMode { "absolute" }; // or "dB"
-};
 
 class BufferAudioSource : public AudioSource
 {

--- a/src/cpp_ui/Preferences.h
+++ b/src/cpp_ui/Preferences.h
@@ -1,0 +1,18 @@
+#pragma once
+#include <juce_core/juce_core.h>
+
+struct Preferences
+{
+    juce::String fontFamily;
+    int fontSize { 10 };
+    juce::String theme { "Dark" };
+    juce::String exportDir;
+    int sampleRate { 44100 };
+    double testStepDuration { 30.0 };
+    bool trackMetadata { false };
+    double targetOutputAmplitude { 0.25 };
+    juce::String crossfadeCurve { "linear" };
+    juce::String amplitudeDisplayMode { "absolute" }; // or "dB"
+    bool applyTargetAmplitude { true };
+    juce::var defaultVoice;
+};

--- a/src/cpp_ui/PreferencesDialog.cpp
+++ b/src/cpp_ui/PreferencesDialog.cpp
@@ -1,6 +1,7 @@
 #include <juce_gui_basics/juce_gui_basics.h>
 #include <juce_gui_extra/juce_gui_extra.h>
 #include <cmath>
+#include "Preferences.h"
 
 using namespace juce;
 
@@ -18,21 +19,6 @@ static double dbToAmplitude (double db)
 }
 }
 
-struct Preferences
-{
-    String fontFamily;
-    int fontSize { 10 };
-    String theme { "Dark" };
-    String exportDir;
-    int sampleRate { 44100 };
-    double testStepDuration { 30.0 };
-    bool trackMetadata { false };
-    double targetOutputAmplitude { 0.25 };
-    String crossfadeCurve { "linear" };
-    String amplitudeDisplayMode { "absolute" }; // or "dB"
-    bool applyTargetAmplitude { true };
-    var defaultVoice;
-};
 
 class PreferencesDialog  : public Component,
                            private Button::Listener,
@@ -285,4 +271,23 @@ private:
         targetAmpSlider.setValue (value, dontSendNotification);
     }
 };
+
+bool showPreferencesDialog (Preferences& prefs)
+{
+    PreferencesDialog dialog (prefs);
+    DialogWindow::LaunchOptions opts;
+    opts.content.setOwned (&dialog);
+    opts.dialogTitle = "Preferences";
+    opts.dialogBackgroundColour = Colours::lightgrey;
+    opts.escapeKeyTriggersCloseButton = true;
+    opts.useNativeTitleBar = true;
+    opts.resizable = false;
+    int result = opts.runModal();
+    if (result != 0 && dialog.wasAccepted())
+    {
+        prefs = dialog.getPreferences();
+        return true;
+    }
+    return false;
+}
 

--- a/src/cpp_ui/main.cpp
+++ b/src/cpp_ui/main.cpp
@@ -9,12 +9,14 @@
 #include <memory>
 
 #include "DefaultVoiceDialog.h"
+#include "Preferences.h"
 
 // Forward declaration of theme helper implemented in Themes.cpp
 extern void applyTheme (juce::LookAndFeel_V4&, const juce::String&);
 
 // include dialog implementations that currently only exist as .cpp files
 #include "SubliminalDialog.cpp"
+#include "PreferencesDialog.cpp"
 
 using namespace juce;
 
@@ -232,10 +234,10 @@ private:
                 saveTrack(false);
                 break;
             case menuPreferences:
-                AlertWindow::showMessageBoxAsync (AlertWindow::InfoIcon,
-                                                   "Preferences",
-                                                   "Preferences dialog not available");
+            {
+                showPreferencesDialog (prefs);
                 break;
+            }
             case menuDefaults:
             {
                 DefaultVoiceDialog dlg (prefs);


### PR DESCRIPTION
## Summary
- add a shared `Preferences` struct for the C++ UI
- wire `DefaultVoiceDialog`, `FrequencyTesterDialog` and `PreferencesDialog` to use the common struct
- implement `showPreferencesDialog` and invoke it from the menu handler

## Testing
- `cmake --preset=default` *(fails: Could not find JUCE)*
- `cmake --build --preset=default` *(fails: build files missing)*

------
https://chatgpt.com/codex/tasks/task_e_685c0d6ed59c832dafbf2176c5f2b0ee