### PR TITLE
Integrate UI in audio main

### DIFF
--- a/src/cpp_audio/main.cpp
+++ b/src/cpp_audio/main.cpp
@@ -2,44 +2,13 @@
 #include "AudioUtils.h"
 #include <juce_core/juce_core.h>
 #include <juce_audio_formats/juce_audio_formats.h>
+#include <juce_gui_basics/juce_gui_basics.h>
+
+#define DIY_AV_UI_NO_MAIN
+#include "../cpp_ui/main.cpp"
 
 int main (int argc, char* argv[])
 {
-    juce::ConsoleApplication app (argc, argv);
-
-    if (argc < 2 || argc > 4)
-    {
-        juce::Logger::writeToLog("Usage: diy_av_audio_cpp <input.json> [output.wav] [extra_steps.json]");
-        return 1;
-    }
-
-    juce::File inFile(argv[1]);
-    Track track = loadTrackFromJson(inFile);
-    juce::File outFile;
-    if (argc >= 3)
-        outFile = juce::File(argv[2]);
-    else
-        outFile = juce::File(track.settings.outputFilename);
-
-    if (argc == 4)
-    {
-        juce::File stepsFile(argv[3]);
-        int added = loadExternalStepsFromJson(stepsFile, track.steps);
-        juce::Logger::writeToLog(juce::String("Loaded ") + juce::String(added) + " external step(s)");
-    }
-
-    double sampleRate = track.settings.sampleRate;
-
-    juce::AudioBuffer<float> trackBuffer = assembleTrack(track);
-
-    // Normalize final track to -12 dBFS (0.25)
-    float peak = 0.0f;
-    for (int ch = 0; ch < trackBuffer.getNumChannels(); ++ch)
-        peak = std::max(peak, trackBuffer.getMagnitude(ch, 0, trackBuffer.getNumSamples()));
-    if (peak > 0.0f)
-        trackBuffer.applyGain(0.25f / peak);
-
-    writeWavFile(outFile, trackBuffer, sampleRate);
-    return 0;
+    return juce::JUCEApplicationBase::main (argc, argv, new DiyAvApplication());
 }
 

--- a/src/cpp_ui/main.cpp
+++ b/src/cpp_ui/main.cpp
@@ -401,5 +401,7 @@ private:
     std::unique_ptr<MainWindow> mainWindow;
 };
 
+#ifndef DIY_AV_UI_NO_MAIN
 START_JUCE_APPLICATION (DiyAvApplication)
+#endif
 


### PR DESCRIPTION
## Summary
- modify cpp_audio main to launch the GUI
- allow cpp_ui main to be built without its own entry point

## Testing
- `cmake -S . -B build` *(fails: Could not find a package configuration file provided by "JUCE")*
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685c10539780832db5b3e49edd1f65cb