### PR TITLE
Fix ConsoleApplication ctor call

### DIFF
--- a/src/cpp_audio/main.cpp
+++ b/src/cpp_audio/main.cpp
@@ -5,7 +5,7 @@
 
 int main (int argc, char* argv[])
 {
-    juce::ConsoleApplication app (argc, argv);
+    juce::ConsoleApplication app;
 
     if (argc < 2 || argc > 4)
     {


### PR DESCRIPTION
## Summary
- correct JUCE `ConsoleApplication` constructor usage

## Testing
- `cmake -B build -S .` *(fails: JUCE directory missing)*

------
https://chatgpt.com/codex/tasks/task_e_685c44734634832db0e8107cbb9b5b40