### PR TITLE
Fix missing M_PI constant

### DIFF
--- a/src/cpp_audio/Common.cpp
+++ b/src/cpp_audio/Common.cpp
@@ -1,5 +1,11 @@
 #include "Common.h"
+#ifndef _USE_MATH_DEFINES
+#define _USE_MATH_DEFINES
+#endif
 #include <cmath>
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
 #include <algorithm>
 #include <numeric>
 #include <random>


### PR DESCRIPTION
## Summary
- add `_USE_MATH_DEFINES` and fallback `M_PI` definition in Common.cpp
- run CMake configuration to ensure no compiler errors

## Testing
- `cmake --preset=default` *(fails: JUCE directory missing)*
- `cmake --build --preset=default` *(fails: build.ninja missing)*

------
https://chatgpt.com/codex/tasks/task_e_685c447e1b40832d936030e8fd279dad