### PR TITLE
Fix incorrect getProperty usage

### DIFF
--- a/src/cpp_audio/Track.cpp
+++ b/src/cpp_audio/Track.cpp
@@ -1,6 +1,7 @@
 #include "Track.h"
 #include "AudioUtils.h"
 #include "SynthFunctions.h"
+#include "VarUtils.h"
 #include <juce_data_structures/juce_data_structures.h>
 #include <juce_audio_formats/juce_audio_formats.h>
 #include <juce_dsp/juce_dsp.h>
@@ -91,20 +92,20 @@ Track loadTrackFromJson(const juce::File& file)
     {
         if (auto* gs = obj->getProperty("global_settings").getDynamicObject())
         {
-            track.settings.sampleRate = gs->getProperty("sample_rate", 44100.0);
-            track.settings.crossfadeDuration = gs->getProperty("crossfade_duration", 1.0);
+            track.settings.sampleRate = getPropertyWithDefault(gs, "sample_rate", 44100.0);
+            track.settings.crossfadeDuration = getPropertyWithDefault(gs, "crossfade_duration", 1.0);
             track.settings.crossfadeCurve = gs->getProperty("crossfade_curve").toString();
-            track.settings.outputFilename = gs->getProperty("output_filename", "my_track.wav").toString();
+            track.settings.outputFilename = getPropertyWithDefault(gs, "output_filename", juce::String("my_track.wav")).toString();
         }
 
         if (auto* bg = obj->getProperty("background_noise").getDynamicObject())
         {
             track.backgroundNoise.filePath = bg->getProperty("file_path").toString();
-            track.backgroundNoise.amp = bg->getProperty("amp", 0.0);
-            track.backgroundNoise.pan = bg->getProperty("pan", 0.0);
-            track.backgroundNoise.startTime = bg->getProperty("start_time", 0.0);
-            track.backgroundNoise.fadeIn = bg->getProperty("fade_in", 0.0);
-            track.backgroundNoise.fadeOut = bg->getProperty("fade_out", 0.0);
+            track.backgroundNoise.amp = getPropertyWithDefault(bg, "amp", 0.0);
+            track.backgroundNoise.pan = getPropertyWithDefault(bg, "pan", 0.0);
+            track.backgroundNoise.startTime = getPropertyWithDefault(bg, "start_time", 0.0);
+            track.backgroundNoise.fadeIn = getPropertyWithDefault(bg, "fade_in", 0.0);
+            track.backgroundNoise.fadeOut = getPropertyWithDefault(bg, "fade_out", 0.0);
             if (auto* envArr = bg->getProperty("amp_envelope").getArray())
             {
                 for (const auto& p : *envArr)
@@ -128,12 +129,12 @@ Track loadTrackFromJson(const juce::File& file)
                 {
                     clip.filePath = cobj->getProperty("file_path").toString();
                     clip.description = cobj->getProperty("description").toString();
-                    clip.start = cobj->getProperty("start", cobj->getProperty("start_time", 0.0));
-                    clip.duration = cobj->getProperty("duration", 0.0);
-                    clip.amp = cobj->getProperty("amp", cobj->getProperty("gain", 1.0));
-                    clip.pan = cobj->getProperty("pan", 0.0);
-                    clip.fadeIn = cobj->getProperty("fade_in", 0.0);
-                    clip.fadeOut = cobj->getProperty("fade_out", 0.0);
+                    clip.start = getPropertyWithDefault(cobj, "start", getPropertyWithDefault(cobj, "start_time", 0.0));
+                    clip.duration = getPropertyWithDefault(cobj, "duration", 0.0);
+                    clip.amp = getPropertyWithDefault(cobj, "amp", getPropertyWithDefault(cobj, "gain", 1.0));
+                    clip.pan = getPropertyWithDefault(cobj, "pan", 0.0);
+                    clip.fadeIn = getPropertyWithDefault(cobj, "fade_in", 0.0);
+                    clip.fadeOut = getPropertyWithDefault(cobj, "fade_out", 0.0);
                 }
                 track.clips.push_back(std::move(clip));
             }
@@ -146,7 +147,7 @@ Track loadTrackFromJson(const juce::File& file)
                 Step step;
                 if (auto* sobj = s.getDynamicObject())
                 {
-                    step.durationSeconds = sobj->getProperty("duration", 0.0);
+                    step.durationSeconds = getPropertyWithDefault(sobj, "duration", 0.0);
                     step.description = sobj->getProperty("description").toString();
                     if (auto* voicesVar = sobj->getProperty("voices").getArray())
                     {
@@ -156,7 +157,7 @@ Track loadTrackFromJson(const juce::File& file)
                             if (auto* vobj = v.getDynamicObject())
                             {
                                 voice.synthFunction = vobj->getProperty("synth_function_name").toString().toStdString();
-                                voice.isTransition = vobj->getProperty("is_transition", false);
+                                voice.isTransition = getPropertyWithDefault(vobj, "is_transition", false);
                                 if (auto* paramsObj = vobj->getProperty("params").getDynamicObject())
                                     voice.params = *paramsObj;
                                 voice.description = vobj->getProperty("description").toString();
@@ -286,7 +287,7 @@ int loadExternalStepsFromJson(const juce::File& file, std::vector<Step>& steps)
                         continue;
 
                     Step step;
-                    step.durationSeconds = sobj->getProperty("duration", 0.0);
+                    step.durationSeconds = getPropertyWithDefault(sobj, "duration", 0.0);
                     step.description = sobj->getProperty("description").toString();
 
                     if (auto* voicesVar = sobj->getProperty("voices").getArray())
@@ -297,7 +298,7 @@ int loadExternalStepsFromJson(const juce::File& file, std::vector<Step>& steps)
                             if (auto* vobj = v.getDynamicObject())
                             {
                                 voice.synthFunction = vobj->getProperty("synth_function_name").toString().toStdString();
-                                voice.isTransition = vobj->getProperty("is_transition", false);
+                                voice.isTransition = getPropertyWithDefault(vobj, "is_transition", false);
                                 if (auto* paramsObj = vobj->getProperty("params").getDynamicObject())
                                     voice.params = *paramsObj;
                                 voice.description = vobj->getProperty("description").toString();

--- a/src/cpp_audio/VarUtils.h
+++ b/src/cpp_audio/VarUtils.h
@@ -1,0 +1,11 @@
+#pragma once
+#include <juce_core/juce_core.h>
+
+inline juce::var getPropertyWithDefault(const juce::DynamicObject* obj,
+                                        const juce::Identifier& name,
+                                        const juce::var& defaultValue)
+{
+    if (obj != nullptr && obj->hasProperty(name))
+        return obj->getProperty(name);
+    return defaultValue;
+}

--- a/src/cpp_audio/presets/NoiseParams.cpp
+++ b/src/cpp_audio/presets/NoiseParams.cpp
@@ -1,4 +1,5 @@
 #include "NoiseParams.h"
+#include "../VarUtils.h"
 
 using namespace juce;
 
@@ -44,25 +45,25 @@ NoiseParams loadNoiseParams(const File& file)
     var root = JSON::parse(file.loadFileAsString());
     if (auto* obj = root.getDynamicObject())
     {
-        params.durationSeconds = obj->getProperty("duration_seconds", params.durationSeconds);
-        params.sampleRate = obj->getProperty("sample_rate", params.sampleRate);
-        params.noiseType = obj->getProperty("noise_type", params.noiseType).toString();
-        params.lfoWaveform = obj->getProperty("lfo_waveform", params.lfoWaveform).toString();
-        params.transition = obj->getProperty("transition", params.transition);
-        params.lfoFreq = obj->getProperty("lfo_freq", params.lfoFreq);
-        params.startLfoFreq = obj->getProperty("start_lfo_freq", params.startLfoFreq);
-        params.endLfoFreq = obj->getProperty("end_lfo_freq", params.endLfoFreq);
+        params.durationSeconds = getPropertyWithDefault(obj, "duration_seconds", params.durationSeconds);
+        params.sampleRate = getPropertyWithDefault(obj, "sample_rate", params.sampleRate);
+        params.noiseType = getPropertyWithDefault(obj, "noise_type", params.noiseType).toString();
+        params.lfoWaveform = getPropertyWithDefault(obj, "lfo_waveform", params.lfoWaveform).toString();
+        params.transition = getPropertyWithDefault(obj, "transition", params.transition);
+        params.lfoFreq = getPropertyWithDefault(obj, "lfo_freq", params.lfoFreq);
+        params.startLfoFreq = getPropertyWithDefault(obj, "start_lfo_freq", params.startLfoFreq);
+        params.endLfoFreq = getPropertyWithDefault(obj, "end_lfo_freq", params.endLfoFreq);
         params.sweeps = obj->getProperty("sweeps");
-        params.startLfoPhaseOffsetDeg = obj->getProperty("start_lfo_phase_offset_deg", params.startLfoPhaseOffsetDeg);
-        params.endLfoPhaseOffsetDeg = obj->getProperty("end_lfo_phase_offset_deg", params.endLfoPhaseOffsetDeg);
-        params.startIntraPhaseOffsetDeg = obj->getProperty("start_intra_phase_offset_deg", params.startIntraPhaseOffsetDeg);
-        params.endIntraPhaseOffsetDeg = obj->getProperty("end_intra_phase_offset_deg", params.endIntraPhaseOffsetDeg);
-        params.initialOffset = obj->getProperty("initial_offset", params.initialOffset);
-        params.postOffset = obj->getProperty("post_offset", params.postOffset);
-        params.inputAudioPath = obj->getProperty("input_audio_path", params.inputAudioPath).toString();
-        params.startTime = obj->getProperty("start_time", params.startTime);
-        params.fadeIn = obj->getProperty("fade_in", params.fadeIn);
-        params.fadeOut = obj->getProperty("fade_out", params.fadeOut);
+        params.startLfoPhaseOffsetDeg = getPropertyWithDefault(obj, "start_lfo_phase_offset_deg", params.startLfoPhaseOffsetDeg);
+        params.endLfoPhaseOffsetDeg = getPropertyWithDefault(obj, "end_lfo_phase_offset_deg", params.endLfoPhaseOffsetDeg);
+        params.startIntraPhaseOffsetDeg = getPropertyWithDefault(obj, "start_intra_phase_offset_deg", params.startIntraPhaseOffsetDeg);
+        params.endIntraPhaseOffsetDeg = getPropertyWithDefault(obj, "end_intra_phase_offset_deg", params.endIntraPhaseOffsetDeg);
+        params.initialOffset = getPropertyWithDefault(obj, "initial_offset", params.initialOffset);
+        params.postOffset = getPropertyWithDefault(obj, "post_offset", params.postOffset);
+        params.inputAudioPath = getPropertyWithDefault(obj, "input_audio_path", params.inputAudioPath).toString();
+        params.startTime = getPropertyWithDefault(obj, "start_time", params.startTime);
+        params.fadeIn = getPropertyWithDefault(obj, "fade_in", params.fadeIn);
+        params.fadeOut = getPropertyWithDefault(obj, "fade_out", params.fadeOut);
         params.ampEnvelope = obj->getProperty("amp_envelope");
     }
     return params;

--- a/src/cpp_audio/synths/NoiseFlanger.cpp
+++ b/src/cpp_audio/synths/NoiseFlanger.cpp
@@ -1,5 +1,6 @@
 #include "SynthFunctions.h"
 #include "AudioUtils.h"
+#include "../VarUtils.h"
 #include <juce_dsp/juce_dsp.h>
 #include <vector>
 #include <algorithm>
@@ -171,8 +172,8 @@ AudioBuffer<float> generateSweptNotchPinkSound(double duration,
                 }
                 else if (auto* obj = e.getDynamicObject())
                 {
-                    minFreq = obj->getProperty("start_min", obj->getProperty("min", minFreq));
-                    maxFreq = obj->getProperty("start_max", obj->getProperty("max", maxFreq));
+                    minFreq = getPropertyWithDefault(obj, "start_min", getPropertyWithDefault(obj, "min", minFreq));
+                    maxFreq = getPropertyWithDefault(obj, "start_max", getPropertyWithDefault(obj, "max", maxFreq));
                 }
             }
         }
@@ -284,8 +285,8 @@ AudioBuffer<float> generateSweptNotchPinkSoundTransition(double duration,
                 }
                 else if (auto* obj = e.getDynamicObject())
                 {
-                    minFreqStart = obj->getProperty("start_min", obj->getProperty("min", minFreqStart));
-                    maxFreqStart = obj->getProperty("start_max", obj->getProperty("max", maxFreqStart));
+                    minFreqStart = getPropertyWithDefault(obj, "start_min", getPropertyWithDefault(obj, "min", minFreqStart));
+                    maxFreqStart = getPropertyWithDefault(obj, "start_max", getPropertyWithDefault(obj, "max", maxFreqStart));
                 }
             }
         }
@@ -308,8 +309,8 @@ AudioBuffer<float> generateSweptNotchPinkSoundTransition(double duration,
                 }
                 else if (auto* obj = e.getDynamicObject())
                 {
-                    minFreqEnd = obj->getProperty("end_min", obj->getProperty("min", minFreqEnd));
-                    maxFreqEnd = obj->getProperty("end_max", obj->getProperty("max", maxFreqEnd));
+                    minFreqEnd = getPropertyWithDefault(obj, "end_min", getPropertyWithDefault(obj, "min", minFreqEnd));
+                    maxFreqEnd = getPropertyWithDefault(obj, "end_max", getPropertyWithDefault(obj, "max", maxFreqEnd));
                 }
             }
         }

--- a/src/cpp_audio/ui/DefaultVoiceDialog.cpp
+++ b/src/cpp_audio/ui/DefaultVoiceDialog.cpp
@@ -2,6 +2,7 @@
 #include <juce_gui_basics/juce_gui_basics.h>
 #include <juce_data_structures/juce_data_structures.h>
 #include <juce_events/juce_events.h>
+#include "../VarUtils.h"
 
 using namespace juce;
 
@@ -45,7 +46,7 @@ DefaultVoiceDialog::DefaultVoiceDialog(Preferences& prefs)
     if (auto* obj = preferences.defaultVoice.getDynamicObject())
     {
         synthEditor.setText(obj->getProperty("synth_function_name").toString());
-        transitionToggle.setToggleState(obj->getProperty("is_transition", false), dontSendNotification);
+        transitionToggle.setToggleState(getPropertyWithDefault(obj, "is_transition", false), dontSendNotification);
         if (auto* p = obj->getProperty("params").getDynamicObject())
             paramsEditor.setText(JSON::toString(var(p)));
         if (auto* e = obj->getProperty("volume_envelope").getDynamicObject())

--- a/src/cpp_audio/ui/StepListPanel.cpp
+++ b/src/cpp_audio/ui/StepListPanel.cpp
@@ -1,5 +1,6 @@
 
 #include "StepListPanel.h"
+#include "../VarUtils.h"
 
 using namespace juce;
 
@@ -219,7 +220,7 @@ void StepListPanel::duplicateStep()
                 {
                     if (auto* sobj = s.getDynamicObject())
                     {
-                        double dur = sobj->getProperty("duration", 0.0);
+                        double dur = getPropertyWithDefault(sobj, "duration", 0.0);
                         if (dur <= 0.0)
                             continue;
                         String desc = sobj->getProperty("description").toString();


### PR DESCRIPTION
## Summary
- add helper `getPropertyWithDefault` for juce::DynamicObject
- use helper in Track, NoiseParams, NoiseFlanger and UI components
- avoid passing default arg directly to `DynamicObject::getProperty`

## Testing
- `cmake -S . -B build` *(fails: JUCE subdirectory missing)*

------
https://chatgpt.com/codex/tasks/task_e_685c4487d72c832db23d02c085a4e097