### PR TITLE
Fix BufferAudioSource override

### DIFF
--- a/src/cpp_audio/BufferAudioSource.h
+++ b/src/cpp_audio/BufferAudioSource.h
@@ -53,7 +53,7 @@ public:
     juce::int64 getTotalLength() const override { return buffer.getNumSamples(); }
     bool isLooping() const override { return looping; }
     void setLooping(bool shouldLoop) override { looping = shouldLoop; }
-    bool isReady() const override { return buffer.getNumSamples() > 0; }
+    bool isReady() const { return buffer.getNumSamples() > 0; }
 
 private:
     juce::AudioBuffer<float> buffer;


### PR DESCRIPTION
## Summary
- fix isReady signature by removing incorrect `override`

## Testing
- `cmake --preset=default` *(fails: JUCE directory missing)*
- `cmake --build --preset=default` *(fails: build.ninja not generated)*

------
https://chatgpt.com/codex/tasks/task_e_685c448f5914832d83e580e98c0c031d