### PR TITLE
Fix property assignments in Track

### DIFF
--- a/src/cpp_audio/Track.cpp
+++ b/src/cpp_audio/Track.cpp
@@ -155,11 +155,14 @@ Track loadTrackFromJson(const juce::File& file)
                             Voice voice;
                             if (auto* vobj = v.getDynamicObject())
                             {
-                                voice.synthFunction = vobj->getProperty("synth_function_name").toString().toStdString();
+                                voice.synthFunction =
+                                    vobj->getProperty("synth_function_name").toString().toStdString();
                                 voice.isTransition = vobj->getProperty("is_transition", false);
-                                if (auto* paramsObj = vobj->getProperty("params").getDynamicObject())
-                                    voice.params = *paramsObj;
-                                voice.description = vobj->getProperty("description").toString();
+                                if (auto* paramsObj =
+                                        vobj->getProperty("params").getDynamicObject())
+                                    voice.params = paramsObj->getProperties();
+                                voice.description =
+                                    vobj->getProperty("description").toString();
                             }
                             step.voices.push_back(std::move(voice));
                         }
@@ -250,7 +253,8 @@ bool saveTrackToJson(const Track& track, const juce::File& file)
             for (const auto& voice : step.voices)
             {
                 auto* vobj = new juce::DynamicObject();
-                vobj->setProperty("synth_function_name", voice.synthFunction);
+                vobj->setProperty("synth_function_name",
+                                   juce::String(voice.synthFunction));
                 vobj->setProperty("is_transition", voice.isTransition);
                 vobj->setProperty("params", namedValueSetToVar(voice.params));
                 vobj->setProperty("description", voice.description);
@@ -296,11 +300,14 @@ int loadExternalStepsFromJson(const juce::File& file, std::vector<Step>& steps)
                             Voice voice;
                             if (auto* vobj = v.getDynamicObject())
                             {
-                                voice.synthFunction = vobj->getProperty("synth_function_name").toString().toStdString();
+                                voice.synthFunction =
+                                    vobj->getProperty("synth_function_name").toString().toStdString();
                                 voice.isTransition = vobj->getProperty("is_transition", false);
-                                if (auto* paramsObj = vobj->getProperty("params").getDynamicObject())
-                                    voice.params = *paramsObj;
-                                voice.description = vobj->getProperty("description").toString();
+                                if (auto* paramsObj =
+                                        vobj->getProperty("params").getDynamicObject())
+                                    voice.params = paramsObj->getProperties();
+                                voice.description =
+                                    vobj->getProperty("description").toString();
                             }
                             step.voices.push_back(std::move(voice));
                         }


### PR DESCRIPTION
## Summary
- handle NamedValueSet conversion from DynamicObject properties
- convert std::string to `juce::String` before storing to `DynamicObject`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685c44ab2624832dbf3333cdba132ff4