### PR TITLE
Fix FileChooser compile errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,14 +98,18 @@ target_link_libraries(AudioApp
       juce::juce_core
       juce::juce_events
       juce::juce_audio_utils
-			juce::juce_audio_basics
-			juce::juce_audio_processors
-			juce::juce_audio_device
-			juce::juce_gui_basics
-			juce::juce_dsp
-			juce::juce_events
+                        juce::juce_audio_basics
+                        juce::juce_audio_processors
+                        juce::juce_audio_device
+                        juce::juce_gui_basics
+                        juce::juce_dsp
+                        juce::juce_events
       # add additional juce::<module> as needed
 )
+
+# Enable modal loops so that the traditional synchronous FileChooser
+# convenience methods (browseForFileToOpen, etc.) are available.
+target_compile_definitions(AudioApp PRIVATE JUCE_MODAL_LOOPS_PERMITTED=1)
 
 # (Optional) Set output directory for the binary
 # set_target_properties(AudioApp PROPERTIES

--- a/src/cpp_audio/CMakeLists.txt
+++ b/src/cpp_audio/CMakeLists.txt
@@ -69,16 +69,21 @@ target_include_directories(AudioApp
 target_link_libraries(AudioApp
     PRIVATE
         juce::juce_core
-				juce::juce_audio_basics
-				juce::juce_audio_formats
-				juce::juce_audio_devices
+                                juce::juce_audio_basics
+                                juce::juce_audio_formats
+                                juce::juce_audio_devices
         juce::juce_audio_utils
-				juce::juce_data_structures
-				juce::juce_gui_basics
-				juce::juce_gui_extra
-				juce::juce_dsp
-				juce::juce_events
+                                juce::juce_data_structures
+                                juce::juce_gui_basics
+                                juce::juce_gui_extra
+                                juce::juce_dsp
+                                juce::juce_events
         # add other juce::<module> targets as needed
 )
+
+# JUCE's synchronous FileChooser methods are disabled unless this
+# definition is enabled. Some UI components still rely on functions like
+# browseForFileToOpen(), so enable modal loops explicitly.
+target_compile_definitions(AudioApp PRIVATE JUCE_MODAL_LOOPS_PERMITTED=1)
 
 


### PR DESCRIPTION
## Summary
- enable JUCE modal loops so synchronous FileChooser calls compile

## Testing
- `cmake --preset=default` *(fails: JUCE directory missing)*

------
https://chatgpt.com/codex/tasks/task_e_685c44c2d178832dba73fa47b55e855d