### PR TITLE
Fix getOwner call in StepModel and VoiceModel

### DIFF
--- a/src/cpp_audio/models/StepModel.cpp
+++ b/src/cpp_audio/models/StepModel.cpp
@@ -1,7 +1,7 @@
 #include "StepModel.h"
 
-StepModel::StepModel(std::vector<Step>* stepsIn)
-    : steps(stepsIn) {}
+StepModel::StepModel(std::vector<Step>* stepsIn, juce::TableListBox* ownerIn)
+    : steps(stepsIn), owner(ownerIn) {}
 
 int StepModel::getNumRows()
 {

--- a/src/cpp_audio/models/StepModel.h
+++ b/src/cpp_audio/models/StepModel.h
@@ -8,7 +8,10 @@
 class StepModel : public juce::TableListBoxModel
 {
 public:
-    StepModel(std::vector<Step>* steps = nullptr);
+    StepModel(std::vector<Step>* steps = nullptr, juce::TableListBox* owner = nullptr);
+
+    void setOwner(juce::TableListBox* newOwner) { owner = newOwner; }
+    juce::TableListBox* getOwner() const { return owner; }
 
     int getNumRows() override;
     void paintRowBackground(juce::Graphics& g, int rowNumber, int width, int height, bool rowIsSelected) override;
@@ -18,4 +21,5 @@ public:
 
 private:
     std::vector<Step>* steps;
+    juce::TableListBox* owner { nullptr };
 };

--- a/src/cpp_audio/models/VoiceModel.cpp
+++ b/src/cpp_audio/models/VoiceModel.cpp
@@ -1,8 +1,8 @@
 #include "VoiceModel.h"
 #include <cmath>
 
-VoiceModel::VoiceModel(std::vector<Voice>* voicesIn)
-    : voices(voicesIn) {}
+VoiceModel::VoiceModel(std::vector<Voice>* voicesIn, juce::TableListBox* ownerIn)
+    : voices(voicesIn), owner(ownerIn) {}
 
 int VoiceModel::getNumRows()
 {

--- a/src/cpp_audio/models/VoiceModel.h
+++ b/src/cpp_audio/models/VoiceModel.h
@@ -8,7 +8,10 @@
 class VoiceModel : public juce::TableListBoxModel
 {
 public:
-    VoiceModel(std::vector<Voice>* voices = nullptr);
+    VoiceModel(std::vector<Voice>* voices = nullptr, juce::TableListBox* owner = nullptr);
+
+    void setOwner(juce::TableListBox* newOwner) { owner = newOwner; }
+    juce::TableListBox* getOwner() const { return owner; }
 
     int getNumRows() override;
     void paintRowBackground(juce::Graphics& g, int rowNumber, int width, int height, bool rowIsSelected) override;
@@ -20,4 +23,5 @@ private:
     juce::String formatNumber(const juce::var& value) const;
     juce::String getBeatFrequency(const juce::NamedValueSet& params, bool isTransition) const;
     std::vector<Voice>* voices;
+    juce::TableListBox* owner { nullptr };
 };


### PR DESCRIPTION
## Summary
- add owner pointers to `StepModel` and `VoiceModel`
- expose `getOwner` and `setOwner` in both models
- update constructors to accept an optional owner pointer

## Testing
- `cmake --preset=default` *(fails: JUCE directory missing)*
- `cmake --build --preset=default` *(fails: build.ninja missing)*

------
https://chatgpt.com/codex/tasks/task_e_685c44b94118832d9b5a6ab0048509bb