### PR TITLE
Fix missing includes for C++ synth modules

### DIFF
--- a/src/cpp_audio/synths/IsochronicTone.cpp
+++ b/src/cpp_audio/synths/IsochronicTone.cpp
@@ -1,6 +1,7 @@
 #include "SynthFunctions.h"
 #include "AudioUtils.h"
 #include <cmath>
+#include <algorithm>
 
 using namespace juce;
 

--- a/src/cpp_audio/synths/MonauralBeatStereoAmps.cpp
+++ b/src/cpp_audio/synths/MonauralBeatStereoAmps.cpp
@@ -1,5 +1,7 @@
 #include "SynthFunctions.h"
 #include "AudioUtils.h"
+#include <cmath>
+#include <algorithm>
 
 using namespace juce;
 


### PR DESCRIPTION
## Summary
- add `<algorithm>` header to IsochronicTone synth code
- add `<cmath>` and `<algorithm>` to MonauralBeatStereoAmps synth code

## Testing
- `cmake -B build -S .` *(fails: JUCE submodule missing)*

------
https://chatgpt.com/codex/tasks/task_e_685c44d11148832d8c9c606934f54395