### PR TITLE
Fix JUCE class includes

### DIFF
--- a/src/cpp_audio/ui/OverlayClipPanel.h
+++ b/src/cpp_audio/ui/OverlayClipPanel.h
@@ -1,5 +1,8 @@
 #pragma once
 #include <juce_gui_basics/juce_gui_basics.h>
+#include <juce_audio_devices/juce_audio_devices.h>
+#include <juce_audio_formats/juce_audio_formats.h>
+#include <juce_audio_utils/juce_audio_utils.h>
 #include "OverlayClipDialog.h"
 
 class OverlayClipPanel : public juce::Component,


### PR DESCRIPTION
## Summary
- include JUCE audio headers in `OverlayClipPanel.h`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c44e558a0832d82e4c6b61737590b