### PR TITLE
Fix JUCE dialog modal loops

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,14 +98,19 @@ target_link_libraries(AudioApp
       juce::juce_core
       juce::juce_events
       juce::juce_audio_utils
-			juce::juce_audio_basics
-			juce::juce_audio_processors
-			juce::juce_audio_device
-			juce::juce_gui_basics
-			juce::juce_dsp
-			juce::juce_events
+                        juce::juce_audio_basics
+                        juce::juce_audio_processors
+                        juce::juce_audio_device
+                        juce::juce_gui_basics
+                        juce::juce_dsp
+                        juce::juce_events
       # add additional juce::<module> as needed
 )
+
+# Enable modal loops for JUCE dialogs so that runModal and runModalLoop
+# are available for our UI components like OverlayClipDialog and
+# PreferencesDialog.
+target_compile_definitions(AudioApp PRIVATE JUCE_MODAL_LOOPS_PERMITTED=1)
 
 # (Optional) Set output directory for the binary
 # set_target_properties(AudioApp PROPERTIES

--- a/src/cpp_audio/CMakeLists.txt
+++ b/src/cpp_audio/CMakeLists.txt
@@ -69,16 +69,20 @@ target_include_directories(AudioApp
 target_link_libraries(AudioApp
     PRIVATE
         juce::juce_core
-				juce::juce_audio_basics
-				juce::juce_audio_formats
-				juce::juce_audio_devices
+                                juce::juce_audio_basics
+                                juce::juce_audio_formats
+                                juce::juce_audio_devices
         juce::juce_audio_utils
-				juce::juce_data_structures
-				juce::juce_gui_basics
-				juce::juce_gui_extra
-				juce::juce_dsp
-				juce::juce_events
+                                juce::juce_data_structures
+                                juce::juce_gui_basics
+                                juce::juce_gui_extra
+                                juce::juce_dsp
+                                juce::juce_events
         # add other juce::<module> targets as needed
 )
+
+# Ensure modal loop APIs like runModal and runModalLoop are available
+# for our dialogs when building this standalone target.
+target_compile_definitions(AudioApp PRIVATE JUCE_MODAL_LOOPS_PERMITTED=1)
 
 


### PR DESCRIPTION
## Summary
- enable JUCE modal loops so dialogs compile

## Testing
- `pytest -q`
- `cmake -S . -B build` *(fails: JUCE not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c450fe270832da9556fdb183982e5