### PR TITLE
Fix getProperty with default value retrieval

### DIFF
--- a/src/cpp_audio/Track.cpp
+++ b/src/cpp_audio/Track.cpp
@@ -285,7 +285,8 @@ int loadExternalStepsFromJson(const juce::File &file,
                 voice.synthFunction = vobj->getProperty("synth_function_name")
                                           .toString()
                                           .toStdString();
-                voice.isTransition = vobj->getProperty("is_transition", false);
+                voice.isTransition =
+                    vobj->getProperty("is_transition").withDefault(false);
                 if (auto *paramsObj =
                         vobj->getProperty("params").getDynamicObject())
                   voice.params = paramsObj->getProperties();

--- a/src/cpp_audio/ui/StepListPanel.cpp
+++ b/src/cpp_audio/ui/StepListPanel.cpp
@@ -181,7 +181,8 @@ void StepListPanel::loadExternalSteps()
                 if (auto* sobj = s.getDynamicObject())
                 {
 
-                    double dur = sobj->getProperty("duration", 0.0);
+                    double dur =
+                        sobj->getProperty("duration").withDefault(0.0);
                     if (dur <= 0.0)
                         continue;
                     String desc = sobj->getProperty("description").toString();


### PR DESCRIPTION
## Summary
- fix JUCE DynamicObject getProperty call sites
- use `withDefault` to supply fallback values

## Testing
- `cmake --preset default` *(fails: Parse error in CMakeLists.txt)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c595d3964832d9b62f972bacf493e