### PR TITLE
Fix std::max ambiguity

### DIFF
--- a/src/cpp_audio/synths/IsochronicTone.cpp
+++ b/src/cpp_audio/synths/IsochronicTone.cpp
@@ -33,8 +33,8 @@ AudioBuffer<float> isochronicTone(double duration, double sampleRate, const Name
         return buffer;
 
     double amp        = params.getWithDefault("amp", 0.5);
-    double baseFreq   = std::max(0.0, params.getWithDefault("baseFreq", 200.0));
-    double beatFreq   = std::max(0.0, params.getWithDefault("beatFreq", 4.0));
+    double baseFreq   = std::max(0.0, static_cast<double>(params.getWithDefault("baseFreq", 200.0)));
+    double beatFreq   = std::max(0.0, static_cast<double>(params.getWithDefault("beatFreq", 4.0)));
     double rampPct    = params.getWithDefault("rampPercent", 0.2);
     double gapPct     = params.getWithDefault("gapPercent", 0.15);
     double pan        = params.getWithDefault("pan", 0.0);

--- a/src/cpp_audio/synths/MonauralBeatStereoAmps.cpp
+++ b/src/cpp_audio/synths/MonauralBeatStereoAmps.cpp
@@ -16,8 +16,8 @@ AudioBuffer<float> monauralBeatStereoAmps(double duration, double sampleRate, co
     double ampUL = params.getWithDefault("amp_upper_L", 0.5);
     double ampLR = params.getWithDefault("amp_lower_R", 0.5);
     double ampUR = params.getWithDefault("amp_upper_R", 0.5);
-    double baseF = std::max(0.0, params.getWithDefault("baseFreq", 200.0));
-    double beatF = std::max(0.0, params.getWithDefault("beatFreq", 4.0));
+    double baseF = std::max(0.0, static_cast<double>(params.getWithDefault("baseFreq", 200.0)));
+    double beatF = std::max(0.0, static_cast<double>(params.getWithDefault("beatFreq", 4.0)));
     double startL = params.getWithDefault("startPhaseL", 0.0);
     double startU = params.getWithDefault("startPhaseR", 0.0);
     double phiF = params.getWithDefault("phaseOscFreq", 0.0);


### PR DESCRIPTION
## Summary
- fix ambiguous `std::max` calls in `IsochronicTone` and `MonauralBeatStereoAmps`

## Testing
- `cmake --preset=default` *(fails: Parse error in `CMakeLists.txt`)*

------
https://chatgpt.com/codex/tasks/task_e_685c596804b0832d8930e16f9d626c64