### PR TITLE
Fix sample rate access

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,23 +98,17 @@ target_link_libraries(AudioApp
       juce::juce_core
       juce::juce_events
       juce::juce_audio_utils
-                        juce::juce_audio_basics
-                        juce::juce_audio_processors
-                        juce::juce_audio_device
-                        juce::juce_gui_basics
-                        juce::juce_dsp
-                        juce::juce_events
+      juce::juce_audio_basics
+      juce::juce_audio_processors
+      juce::juce_audio_device
+      juce::juce_gui_basics
+      juce::juce_dsp
+      juce::juce_events
       # add additional juce::<module> as needed
 )
 
-<<<<<<< abcd/fix-missing-runmodal-functions-in-juce-dialog-components
-# Enable modal loops for JUCE dialogs so that runModal and runModalLoop
-# are available for our UI components like OverlayClipDialog and
-# PreferencesDialog.
-=======
-# Enable modal loops so that the traditional synchronous FileChooser
-# convenience methods (browseForFileToOpen, etc.) are available.
->>>>>>> main
+# Enable modal loops so that runModal, runModalLoop and the synchronous
+# FileChooser helpers are available for our dialogs.
 target_compile_definitions(AudioApp PRIVATE JUCE_MODAL_LOOPS_PERMITTED=1)
 
 # (Optional) Set output directory for the binary

--- a/src/cpp_audio/ui/OverlayClipDialog.cpp
+++ b/src/cpp_audio/ui/OverlayClipDialog.cpp
@@ -272,8 +272,9 @@ private:
                                                    "Could not read audio file.");
             return;
         }
+        double sr = reader->sampleRate;
         readerSource.reset(new juce::AudioFormatReaderSource(reader.release(), true));
-        transport.setSource(readerSource.get(), 0, nullptr, readerSource->sampleRate);
+        transport.setSource(readerSource.get(), 0, nullptr, sr);
         transport.start();
         playButton.setButtonText("Stop Clip");
     }

--- a/src/cpp_audio/ui/OverlayClipPanel.cpp
+++ b/src/cpp_audio/ui/OverlayClipPanel.cpp
@@ -120,8 +120,9 @@ void OverlayClipPanel::startPlayback()
     if (!reader)
         return;
 
+    double sr = reader->sampleRate;
     readerSource.reset(new juce::AudioFormatReaderSource(reader.release(), true));
-    transport.setSource(readerSource.get(), 0, nullptr, readerSource->sampleRate);
+    transport.setSource(readerSource.get(), 0, nullptr, sr);
     deviceManager.addAudioCallback(&transport);
     transport.start();
     playButton.setButtonText("Stop Clip");


### PR DESCRIPTION
## Summary
- avoid missing `sampleRate` member when setting AudioTransportSource
- clean up leftover merge markers in `CMakeLists.txt`

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release` *(fails: JUCE directory missing)*
- `cmake --build build --config Release` *(fails: no Makefile generated)*

------
https://chatgpt.com/codex/tasks/task_e_685c59ed6520832da9395c230b8d57bb