### PR TITLE
Fix audio callback type in OverlayClipPanel

### DIFF
--- a/src/cpp_audio/ui/OverlayClipPanel.cpp
+++ b/src/cpp_audio/ui/OverlayClipPanel.cpp
@@ -14,6 +14,7 @@ OverlayClipPanel::OverlayClipPanel()
     }
 
     formatManager.registerBasicFormats();
+    sourcePlayer.setSource(&transport);
 }
 
 OverlayClipPanel::~OverlayClipPanel()
@@ -21,6 +22,7 @@ OverlayClipPanel::~OverlayClipPanel()
     for (auto* b : { &addButton, &editButton, &removeButton, &playButton })
         b->removeListener(this);
     stopPlayback();
+    deviceManager.removeAudioCallback(&sourcePlayer);
 }
 
 int OverlayClipPanel::getNumRows()
@@ -122,7 +124,7 @@ void OverlayClipPanel::startPlayback()
 
     readerSource.reset(new juce::AudioFormatReaderSource(reader.release(), true));
     transport.setSource(readerSource.get(), 0, nullptr, readerSource->sampleRate);
-    deviceManager.addAudioCallback(&transport);
+    deviceManager.addAudioCallback(&sourcePlayer);
     transport.start();
     playButton.setButtonText("Stop Clip");
 }
@@ -133,6 +135,6 @@ void OverlayClipPanel::stopPlayback()
     transport.setSource(nullptr);
     if (readerSource)
         readerSource.reset();
-    deviceManager.removeAudioCallback(&transport);
+    deviceManager.removeAudioCallback(&sourcePlayer);
     playButton.setButtonText("Start Clip");
 }

--- a/src/cpp_audio/ui/OverlayClipPanel.h
+++ b/src/cpp_audio/ui/OverlayClipPanel.h
@@ -34,6 +34,7 @@ private:
     juce::AudioDeviceManager deviceManager;
     juce::AudioFormatManager formatManager;
     juce::AudioTransportSource transport;
+    juce::AudioSourcePlayer sourcePlayer;
     std::unique_ptr<juce::AudioFormatReaderSource> readerSource;
 
     std::vector<OverlayClipDialog::ClipData> clips;


### PR DESCRIPTION
## Summary
- use an `AudioSourcePlayer` in `OverlayClipPanel`
- add/remove the player for audio callbacks instead of the transport

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release` *(fails: Parse error in CMakeLists.txt)*

------
https://chatgpt.com/codex/tasks/task_e_685c5a06db98832dae0fb22f8168e6c2