### PR TITLE
Fix font retrieval

### DIFF
--- a/src/cpp_audio/ui/PreferencesDialog.cpp
+++ b/src/cpp_audio/ui/PreferencesDialog.cpp
@@ -33,7 +33,7 @@ public:
         addAndMakeVisible (&fontFamilyLabel);
         fontFamilyLabel.setText ("Font Family:", dontSendNotification);
         addAndMakeVisible (&fontCombo);
-        fontCombo.addItemList (Font::getAvailableFontNames(), 1);
+        fontCombo.addItemList (Font::getAvailableTypefaces(), 1);
         if (prefs.fontFamily.isNotEmpty())
             fontCombo.setText (prefs.fontFamily, dontSendNotification);
 


### PR DESCRIPTION
## Summary
- use `getAvailableTypefaces` to populate font family list

## Testing
- `cmake --preset=default` *(fails: Parse error in CMakeLists.txt)*

------
https://chatgpt.com/codex/tasks/task_e_685c5a128e2c832da6980a9579be8f58