### PR TITLE
Fix ComboBox methods

### DIFF
--- a/src/cpp_audio/ui/PreferencesDialog.cpp
+++ b/src/cpp_audio/ui/PreferencesDialog.cpp
@@ -52,8 +52,18 @@ public:
         themeCombo.addItem ("Green", 2);
         themeCombo.addItem ("light-blue", 3);
         themeCombo.addItem ("Material", 4);
-        if (auto* item = themeCombo.getItemID (themeCombo.indexOfItemText (prefs.theme)))
-            themeCombo.setText (prefs.theme, dontSendNotification);
+        int foundId = 0;
+        for (int i = 0; i < themeCombo.getNumItems(); ++i)
+        {
+            if (themeCombo.getItemText (i) == prefs.theme)
+            {
+                foundId = themeCombo.getItemId (i);
+                break;
+            }
+        }
+
+        if (foundId != 0)
+            themeCombo.setSelectedId (foundId);
         else
             themeCombo.setSelectedId (1);
 


### PR DESCRIPTION
## Summary
- fix usage of juce::ComboBox methods in PreferencesDialog

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `cmake --preset=default` *(fails: Parse error in CMakeLists.txt)*

------
https://chatgpt.com/codex/tasks/task_e_685c5a1a7050832d87a111acb99333f6