### PR TITLE
Fix compile issues with modern JUCE

### DIFF
--- a/src/cpp_audio/Track.cpp
+++ b/src/cpp_audio/Track.cpp
@@ -152,7 +152,7 @@ Track loadTrackFromJson(const juce::File &file) {
                                           .toString()
                                           .toStdString();
                 voice.isTransition =
-                    vobj->getPropertyWithDefault("is_transition", false);
+                    getPropertyWithDefault(vobj, "is_transition", false);
                 if (auto *paramsObj =
                         vobj->getProperty("params").getDynamicObject())
                   voice.params = paramsObj->getProperties();
@@ -286,7 +286,7 @@ int loadExternalStepsFromJson(const juce::File &file,
                                           .toString()
                                           .toStdString();
                 voice.isTransition =
-                    vobj->getProperty("is_transition").withDefault(false);
+                    withDefault(vobj->getProperty("is_transition"), false);
                 if (auto *paramsObj =
                         vobj->getProperty("params").getDynamicObject())
                   voice.params = paramsObj->getProperties();

--- a/src/cpp_audio/VarUtils.h
+++ b/src/cpp_audio/VarUtils.h
@@ -9,3 +9,8 @@ inline juce::var getPropertyWithDefault(const juce::DynamicObject* obj,
         return obj->getProperty(name);
     return defaultValue;
 }
+
+inline juce::var withDefault(const juce::var& value, const juce::var& defaultValue)
+{
+    return value.isVoid() ? defaultValue : value;
+}

--- a/src/cpp_audio/ui/OverlayClipPanel.cpp
+++ b/src/cpp_audio/ui/OverlayClipPanel.cpp
@@ -125,7 +125,7 @@ void OverlayClipPanel::startPlayback()
     double sr = reader->sampleRate;
     readerSource.reset(new juce::AudioFormatReaderSource(reader.release(), true));
 
-    transport.setSource(readerSource.get(), 0, nullptr, readerSource->sampleRate);
+    transport.setSource(readerSource.get(), 0, nullptr, sr);
     deviceManager.addAudioCallback(&sourcePlayer);
 
     transport.start();

--- a/src/cpp_audio/ui/PreferencesDialog.cpp
+++ b/src/cpp_audio/ui/PreferencesDialog.cpp
@@ -33,7 +33,7 @@ public:
         addAndMakeVisible (&fontFamilyLabel);
         fontFamilyLabel.setText ("Font Family:", dontSendNotification);
         addAndMakeVisible (&fontCombo);
-        fontCombo.addItemList (Font::getAvailableTypefaces(), 1);
+        fontCombo.addItemList (Font::findAllTypefaceNames(), 1);
         if (prefs.fontFamily.isNotEmpty())
             fontCombo.setText (prefs.fontFamily, dontSendNotification);
 

--- a/src/cpp_audio/ui/StepListPanel.cpp
+++ b/src/cpp_audio/ui/StepListPanel.cpp
@@ -182,7 +182,7 @@ void StepListPanel::loadExternalSteps()
                 {
 
                     double dur =
-                        sobj->getProperty("duration").withDefault(0.0);
+                        withDefault(sobj->getProperty("duration"), 0.0);
                     if (dur <= 0.0)
                         continue;
                     String desc = sobj->getProperty("description").toString();


### PR DESCRIPTION
## Summary
- adjust helper utilities for juce::var defaults
- update Track parsing for new helper functions
- change font list retrieval to `Font::findAllTypefaceNames`
- use audio reader sample rate when starting clip playback

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release` *(fails: JUCE directory missing)*

------
https://chatgpt.com/codex/tasks/task_e_685c5c774858832d862cbafebc819926