### PR TITLE
Add header files for synth modules

### DIFF
--- a/src/cpp_audio/synths/BinauralBeat.cpp
+++ b/src/cpp_audio/synths/BinauralBeat.cpp
@@ -1,4 +1,4 @@
-#include "SynthFunctions.h"
+#include "BinauralBeat.h"
 #include "AudioUtils.h"
 #include <vector>
 #include <cmath>

--- a/src/cpp_audio/synths/BinauralBeat.h
+++ b/src/cpp_audio/synths/BinauralBeat.h
@@ -1,0 +1,8 @@
+#pragma once
+#include <juce_audio_basics/juce_audio_basics.h>
+
+juce::AudioBuffer<float> binauralBeat(double duration, double sampleRate,
+                                      const juce::NamedValueSet& params);
+
+juce::AudioBuffer<float> binauralBeatTransition(double duration, double sampleRate,
+                                                const juce::NamedValueSet& params);

--- a/src/cpp_audio/synths/HybridQamMonauralBeat.cpp
+++ b/src/cpp_audio/synths/HybridQamMonauralBeat.cpp
@@ -1,4 +1,4 @@
-#include "SynthFunctions.h"
+#include "HybridQamMonauralBeat.h"
 #include "AudioUtils.h"
 
 using namespace juce;

--- a/src/cpp_audio/synths/HybridQamMonauralBeat.h
+++ b/src/cpp_audio/synths/HybridQamMonauralBeat.h
@@ -1,0 +1,8 @@
+#pragma once
+#include <juce_audio_basics/juce_audio_basics.h>
+
+juce::AudioBuffer<float> hybridQamMonauralBeat(double duration, double sampleRate,
+                                               const juce::NamedValueSet& params);
+
+juce::AudioBuffer<float> hybridQamMonauralBeatTransition(double duration, double sampleRate,
+                                                        const juce::NamedValueSet& params);

--- a/src/cpp_audio/synths/IsochronicTone.cpp
+++ b/src/cpp_audio/synths/IsochronicTone.cpp
@@ -1,4 +1,4 @@
-#include "SynthFunctions.h"
+#include "IsochronicTone.h"
 #include "AudioUtils.h"
 #include <cmath>
 #include <algorithm>

--- a/src/cpp_audio/synths/IsochronicTone.h
+++ b/src/cpp_audio/synths/IsochronicTone.h
@@ -1,0 +1,8 @@
+#pragma once
+#include <juce_audio_basics/juce_audio_basics.h>
+
+juce::AudioBuffer<float> isochronicTone(double duration, double sampleRate,
+                                        const juce::NamedValueSet& params);
+
+juce::AudioBuffer<float> isochronicToneTransition(double duration, double sampleRate,
+                                                  const juce::NamedValueSet& params);

--- a/src/cpp_audio/synths/MonauralBeatStereoAmps.cpp
+++ b/src/cpp_audio/synths/MonauralBeatStereoAmps.cpp
@@ -1,4 +1,4 @@
-#include "SynthFunctions.h"
+#include "MonauralBeatStereoAmps.h"
 #include "AudioUtils.h"
 #include <cmath>
 #include <algorithm>

--- a/src/cpp_audio/synths/MonauralBeatStereoAmps.h
+++ b/src/cpp_audio/synths/MonauralBeatStereoAmps.h
@@ -1,0 +1,8 @@
+#pragma once
+#include <juce_audio_basics/juce_audio_basics.h>
+
+juce::AudioBuffer<float> monauralBeatStereoAmps(double duration, double sampleRate,
+                                                const juce::NamedValueSet& params);
+
+juce::AudioBuffer<float> monauralBeatStereoAmpsTransition(double duration, double sampleRate,
+                                                         const juce::NamedValueSet& params);

--- a/src/cpp_audio/synths/NoiseFlanger.cpp
+++ b/src/cpp_audio/synths/NoiseFlanger.cpp
@@ -1,4 +1,4 @@
-#include "SynthFunctions.h"
+#include "NoiseFlanger.h"
 #include "AudioUtils.h"
 #include "../VarUtils.h"
 #include <juce_dsp/juce_dsp.h>

--- a/src/cpp_audio/synths/NoiseFlanger.h
+++ b/src/cpp_audio/synths/NoiseFlanger.h
@@ -1,0 +1,8 @@
+#pragma once
+#include <juce_audio_basics/juce_audio_basics.h>
+
+juce::AudioBuffer<float> generateSweptNotchPinkSound(double duration, double sampleRate,
+                                                    const juce::NamedValueSet& params);
+
+juce::AudioBuffer<float> generateSweptNotchPinkSoundTransition(double duration, double sampleRate,
+                                                             const juce::NamedValueSet& params);

--- a/src/cpp_audio/synths/QamBeat.cpp
+++ b/src/cpp_audio/synths/QamBeat.cpp
@@ -1,4 +1,4 @@
-#include "SynthFunctions.h"
+#include "QamBeat.h"
 #include "AudioUtils.h"
 
 using namespace juce;

--- a/src/cpp_audio/synths/QamBeat.h
+++ b/src/cpp_audio/synths/QamBeat.h
@@ -1,0 +1,8 @@
+#pragma once
+#include <juce_audio_basics/juce_audio_basics.h>
+
+juce::AudioBuffer<float> qamBeat(double duration, double sampleRate,
+                                 const juce::NamedValueSet& params);
+
+juce::AudioBuffer<float> qamBeatTransition(double duration, double sampleRate,
+                                           const juce::NamedValueSet& params);

--- a/src/cpp_audio/synths/RhythmicWaveshaping.cpp
+++ b/src/cpp_audio/synths/RhythmicWaveshaping.cpp
@@ -1,4 +1,4 @@
-#include "SynthFunctions.h"
+#include "RhythmicWaveshaping.h"
 #include "AudioUtils.h"
 #include <cmath>
 

--- a/src/cpp_audio/synths/RhythmicWaveshaping.h
+++ b/src/cpp_audio/synths/RhythmicWaveshaping.h
@@ -1,0 +1,8 @@
+#pragma once
+#include <juce_audio_basics/juce_audio_basics.h>
+
+juce::AudioBuffer<float> rhythmicWaveshaping(double duration, double sampleRate,
+                                             const juce::NamedValueSet& params);
+
+juce::AudioBuffer<float> rhythmicWaveshapingTransition(double duration, double sampleRate,
+                                                      const juce::NamedValueSet& params);

--- a/src/cpp_audio/synths/SpatialAngleModulation.cpp
+++ b/src/cpp_audio/synths/SpatialAngleModulation.cpp
@@ -1,4 +1,4 @@
-#include "SynthFunctions.h"
+#include "SpatialAngleModulation.h"
 #include "AudioUtils.h"
 
 using namespace juce;

--- a/src/cpp_audio/synths/SpatialAngleModulation.h
+++ b/src/cpp_audio/synths/SpatialAngleModulation.h
@@ -1,0 +1,14 @@
+#pragma once
+#include <juce_audio_basics/juce_audio_basics.h>
+
+juce::AudioBuffer<float> spatialAngleModulation(double duration, double sampleRate,
+                                               const juce::NamedValueSet& params);
+
+juce::AudioBuffer<float> spatialAngleModulationTransition(double duration, double sampleRate,
+                                                         const juce::NamedValueSet& params);
+
+juce::AudioBuffer<float> spatialAngleModulationMonauralBeat(double duration, double sampleRate,
+                                                           const juce::NamedValueSet& params);
+
+juce::AudioBuffer<float> spatialAngleModulationMonauralBeatTransition(double duration, double sampleRate,
+                                                                     const juce::NamedValueSet& params);

--- a/src/cpp_audio/synths/StereoAMIndependent.cpp
+++ b/src/cpp_audio/synths/StereoAMIndependent.cpp
@@ -1,4 +1,4 @@
-#include "SynthFunctions.h"
+#include "StereoAMIndependent.h"
 #include "AudioUtils.h"
 #include <cmath>
 

--- a/src/cpp_audio/synths/StereoAMIndependent.h
+++ b/src/cpp_audio/synths/StereoAMIndependent.h
@@ -1,0 +1,8 @@
+#pragma once
+#include <juce_audio_basics/juce_audio_basics.h>
+
+juce::AudioBuffer<float> stereoAMIndependent(double duration, double sampleRate,
+                                             const juce::NamedValueSet& params);
+
+juce::AudioBuffer<float> stereoAMIndependentTransition(double duration, double sampleRate,
+                                                      const juce::NamedValueSet& params);

--- a/src/cpp_audio/synths/Subliminals.cpp
+++ b/src/cpp_audio/synths/Subliminals.cpp
@@ -1,4 +1,4 @@
-#include "SynthFunctions.h"
+#include "Subliminals.h"
 #include "AudioUtils.h"
 
 using namespace juce;

--- a/src/cpp_audio/synths/Subliminals.h
+++ b/src/cpp_audio/synths/Subliminals.h
@@ -1,0 +1,5 @@
+#pragma once
+#include <juce_audio_basics/juce_audio_basics.h>
+
+juce::AudioBuffer<float> subliminalEncode(double duration, double sampleRate,
+                                          const juce::NamedValueSet& params);

--- a/src/cpp_audio/synths/WaveShapeStereoAm.cpp
+++ b/src/cpp_audio/synths/WaveShapeStereoAm.cpp
@@ -1,4 +1,4 @@
-#include "SynthFunctions.h"
+#include "WaveShapeStereoAm.h"
 #include "AudioUtils.h"
 #include <cmath>
 

--- a/src/cpp_audio/synths/WaveShapeStereoAm.h
+++ b/src/cpp_audio/synths/WaveShapeStereoAm.h
@@ -1,0 +1,8 @@
+#pragma once
+#include <juce_audio_basics/juce_audio_basics.h>
+
+juce::AudioBuffer<float> waveShapeStereoAm(double duration, double sampleRate,
+                                           const juce::NamedValueSet& params);
+
+juce::AudioBuffer<float> waveShapeStereoAmTransition(double duration, double sampleRate,
+                                                    const juce::NamedValueSet& params);


### PR DESCRIPTION
## Summary
- add header files for every synth implementation in `src/cpp_audio/synths`
- include those headers in their corresponding source files

## Testing
- `cmake -S src/cpp_audio -B build` *(fails: Parse error in CMakeLists.txt)*

------
https://chatgpt.com/codex/tasks/task_e_685c8170c748832dba4a02e63342b06b