### PR TITLE
Add missing UI component headers

### DIFF
--- a/src/cpp_audio/ui/PreferencesDialog.cpp
+++ b/src/cpp_audio/ui/PreferencesDialog.cpp
@@ -2,6 +2,7 @@
 #include <juce_gui_extra/juce_gui_extra.h>
 #include <cmath>
 #include "Preferences.h"
+#include "PreferencesDialog.h"
 
 using namespace juce;
 

--- a/src/cpp_audio/ui/PreferencesDialog.h
+++ b/src/cpp_audio/ui/PreferencesDialog.h
@@ -1,0 +1,4 @@
+#pragma once
+#include "Preferences.h"
+
+bool showPreferencesDialog(Preferences& prefs);

--- a/src/cpp_audio/ui/Simulator.cpp
+++ b/src/cpp_audio/ui/Simulator.cpp
@@ -2,6 +2,7 @@
 // Translated from src/ui/simulator.py
 
 #include <juce_gui_basics/juce_gui_basics.h>
+#include "Simulator.h"
 
 // TODO: Implement SimulatorWindow class using JUCE components.
 

--- a/src/cpp_audio/ui/Simulator.h
+++ b/src/cpp_audio/ui/Simulator.h
@@ -1,0 +1,2 @@
+#pragma once
+// Placeholder header for Simulator UI components.

--- a/src/cpp_audio/ui/StepConfigPanel.cpp
+++ b/src/cpp_audio/ui/StepConfigPanel.cpp
@@ -1,132 +1,113 @@
-// Simplified StepConfigPanel implemented with JUCE widgets.  The panel hosts a
-// list of voices for the currently selected step and provides controls for
-// adding, duplicating, deleting and reordering voices.  It mirrors a subset of
-// the behaviour found in the PyQt step configuration panel.
-
-#include <juce_gui_basics/juce_gui_basics.h>
+#include "StepConfigPanel.h"
 
 using namespace juce;
 
-class StepConfigPanel  : public Component,
-                         private ListBoxModel,
-                         private Button::Listener
+StepConfigPanel::StepConfigPanel()
 {
-public:
-    StepConfigPanel()
+    addAndMakeVisible(&voiceList);
+    voiceList.setModel(this);
+
+    addButton.setButtonText("Add Voice");
+    dupButton.setButtonText("Duplicate Voice");
+    removeButton.setButtonText("Remove Voice");
+    upButton.setButtonText("Move Up");
+    downButton.setButtonText("Move Down");
+
+    for (auto* b : { &addButton, &dupButton, &removeButton, &upButton, &downButton })
     {
-        addAndMakeVisible(&voiceList);
-        voiceList.setModel(this);
-
-        addButton.setButtonText("Add Voice");
-        dupButton.setButtonText("Duplicate Voice");
-        removeButton.setButtonText("Remove Voice");
-        upButton.setButtonText("Move Up");
-        downButton.setButtonText("Move Down");
-
-        for (auto* b : { &addButton, &dupButton, &removeButton, &upButton, &downButton })
-        {
-            addAndMakeVisible(b);
-            b->addListener(this);
-        }
+        addAndMakeVisible(b);
+        b->addListener(this);
     }
+}
 
-    ~StepConfigPanel() override
+StepConfigPanel::~StepConfigPanel()
+{
+    for (auto* b : { &addButton, &dupButton, &removeButton, &upButton, &downButton })
+        b->removeListener(this);
+}
+
+int StepConfigPanel::getNumRows()
+{
+    return voices.size();
+}
+
+void StepConfigPanel::paintListBoxItem(int row, Graphics& g, int width, int height, bool selected)
+{
+    if (selected)
+        g.fillAll(Colours::lightblue);
+
+    if (isPositiveAndBelow(row, voices.size()))
     {
-        for (auto* b : { &addButton, &dupButton, &removeButton, &upButton, &downButton })
-            b->removeListener(this);
+        g.setColour(Colours::black);
+        g.drawText(voices[row], 4, 0, width - 4, height, Justification::centredLeft);
     }
+}
 
-    //=========================================================================
-    // ListBoxModel implementation
-    int getNumRows() override { return voices.size(); }
+void StepConfigPanel::resized()
+{
+    auto area = getLocalBounds().reduced(4);
+    voiceList.setBounds(area.removeFromTop(getHeight() - 48));
 
-    void paintListBoxItem(int row, Graphics& g, int width, int height, bool selected) override
+    auto buttons = area.removeFromTop(44);
+    auto each = buttons.getWidth() / 5;
+    addButton.setBounds(buttons.removeFromLeft(each));
+    dupButton.setBounds(buttons.removeFromLeft(each));
+    removeButton.setBounds(buttons.removeFromLeft(each));
+    upButton.setBounds(buttons.removeFromLeft(each));
+    downButton.setBounds(buttons);
+}
+
+void StepConfigPanel::buttonClicked(Button* b)
+{
+    if (b == &addButton)
+        addVoice();
+    else if (b == &dupButton)
+        duplicateVoice();
+    else if (b == &removeButton)
+        removeVoice();
+    else if (b == &upButton)
+        moveVoice(-1);
+    else if (b == &downButton)
+        moveVoice(1);
+
+    voiceList.updateContent();
+    voiceList.repaint();
+}
+
+void StepConfigPanel::addVoice()
+{
+    voices.add("Voice " + String(voices.size() + 1));
+    voiceList.selectRow(voices.size() - 1);
+}
+
+void StepConfigPanel::duplicateVoice()
+{
+    int row = voiceList.getSelectedRow();
+    if (isPositiveAndBelow(row, voices.size()))
     {
-        if (selected)
-            g.fillAll(Colours::lightblue);
-
-        if (isPositiveAndBelow(row, voices.size()))
-        {
-            g.setColour(Colours::black);
-            g.drawText(voices[row], 4, 0, width - 4, height, Justification::centredLeft);
-        }
+        voices.insert(row + 1, voices[row] + " (Copy)");
+        voiceList.selectRow(row + 1);
     }
+}
 
-    //=========================================================================
-    void resized() override
+void StepConfigPanel::removeVoice()
+{
+    int row = voiceList.getSelectedRow();
+    if (isPositiveAndBelow(row, voices.size()))
     {
-        auto area = getLocalBounds().reduced(4);
-        voiceList.setBounds(area.removeFromTop(getHeight() - 48));
-
-        auto buttons = area.removeFromTop(44);
-        auto each = buttons.getWidth() / 5;
-        addButton.setBounds(buttons.removeFromLeft(each));
-        dupButton.setBounds(buttons.removeFromLeft(each));
-        removeButton.setBounds(buttons.removeFromLeft(each));
-        upButton.setBounds(buttons.removeFromLeft(each));
-        downButton.setBounds(buttons);
+        voices.remove(row);
+        if (row > 0)
+            voiceList.selectRow(row - 1);
     }
+}
 
-private:
-    ListBox voiceList;
-    TextButton addButton, dupButton, removeButton, upButton, downButton;
-    StringArray voices;
-
-    //=========================================================================
-    void buttonClicked(Button* b) override
+void StepConfigPanel::moveVoice(int delta)
+{
+    int row = voiceList.getSelectedRow();
+    int target = row + delta;
+    if (isPositiveAndBelow(row, voices.size()) && isPositiveAndBelow(target, voices.size()))
     {
-        if (b == &addButton)
-            addVoice();
-        else if (b == &dupButton)
-            duplicateVoice();
-        else if (b == &removeButton)
-            removeVoice();
-        else if (b == &upButton)
-            moveVoice(-1);
-        else if (b == &downButton)
-            moveVoice(1);
-
-        voiceList.updateContent();
-        voiceList.repaint();
+        voices.move(row, target);
+        voiceList.selectRow(target);
     }
-
-    void addVoice()
-    {
-        voices.add("Voice " + String(voices.size() + 1));
-        voiceList.selectRow(voices.size() - 1);
-    }
-
-    void duplicateVoice()
-    {
-        int row = voiceList.getSelectedRow();
-        if (isPositiveAndBelow(row, voices.size()))
-        {
-            voices.insert(row + 1, voices[row] + " (Copy)");
-            voiceList.selectRow(row + 1);
-        }
-    }
-
-    void removeVoice()
-    {
-        int row = voiceList.getSelectedRow();
-        if (isPositiveAndBelow(row, voices.size()))
-        {
-            voices.remove(row);
-            if (row > 0)
-                voiceList.selectRow(row - 1);
-        }
-    }
-
-    void moveVoice(int delta)
-    {
-        int row = voiceList.getSelectedRow();
-        int target = row + delta;
-        if (isPositiveAndBelow(row, voices.size()) && isPositiveAndBelow(target, voices.size()))
-        {
-            voices.move(row, target);
-            voiceList.selectRow(target);
-        }
-    }
-};
-
-
+}

--- a/src/cpp_audio/ui/StepConfigPanel.h
+++ b/src/cpp_audio/ui/StepConfigPanel.h
@@ -1,0 +1,26 @@
+#pragma once
+#include <juce_gui_basics/juce_gui_basics.h>
+
+class StepConfigPanel : public juce::Component,
+                        private juce::ListBoxModel,
+                        private juce::Button::Listener
+{
+public:
+    StepConfigPanel();
+    ~StepConfigPanel() override;
+
+    int getNumRows() override;
+    void paintListBoxItem(int row, juce::Graphics&, int width, int height, bool selected) override;
+    void resized() override;
+
+private:
+    juce::ListBox voiceList;
+    juce::TextButton addButton, dupButton, removeButton, upButton, downButton;
+    juce::StringArray voices;
+
+    void buttonClicked(juce::Button*) override;
+    void addVoice();
+    void duplicateVoice();
+    void removeVoice();
+    void moveVoice(int delta);
+};

--- a/src/cpp_audio/ui/SubliminalDialog.cpp
+++ b/src/cpp_audio/ui/SubliminalDialog.cpp
@@ -2,6 +2,7 @@
 // Translated from src/audio/ui/subliminal_dialog.py and adapted for JUCE.
 
 #include "../cpp_audio/Track.h"
+#include "SubliminalDialog.h"
 #include <juce_gui_basics/juce_gui_basics.h>
 #include <cmath>
 

--- a/src/cpp_audio/ui/SubliminalDialog.h
+++ b/src/cpp_audio/ui/SubliminalDialog.h
@@ -1,0 +1,30 @@
+#pragma once
+#include "../Track.h"
+#include <juce_gui_basics/juce_gui_basics.h>
+
+struct SubliminalDialog : public juce::Component,
+                          private juce::Button::Listener
+{
+    explicit SubliminalDialog(bool ampInDb = false);
+
+    bool wasAccepted() const;
+    Voice getVoice() const;
+
+    void resized() override;
+
+private:
+    bool amplitudeInDb = false;
+    bool accepted = false;
+    Voice voice;
+
+    juce::Label fileLabel, freqLabel, ampLabel, modeLabel;
+    juce::TextEditor fileEdit;
+    juce::TextButton browseButton { "Browse" };
+    juce::Slider freqSlider { juce::Slider::LinearHorizontal, juce::Slider::TextBoxRight };
+    juce::Slider ampSlider  { juce::Slider::LinearHorizontal, juce::Slider::TextBoxRight };
+    juce::ComboBox modeBox;
+    juce::TextButton addButton { "Add" }, cancelButton { "Cancel" };
+
+    void buttonClicked(juce::Button*) override;
+    void onAccept();
+};

--- a/src/cpp_audio/ui/Themes.cpp
+++ b/src/cpp_audio/ui/Themes.cpp
@@ -1,5 +1,6 @@
 #include <juce_gui_basics/juce_gui_basics.h>
 #include <map>
+#include "Themes.h"
 
 using namespace juce;
 

--- a/src/cpp_audio/ui/Themes.h
+++ b/src/cpp_audio/ui/Themes.h
@@ -1,0 +1,4 @@
+#pragma once
+#include <juce_gui_basics/juce_gui_basics.h>
+
+void applyTheme(juce::LookAndFeel_V4& lf, const juce::String& name);

--- a/src/cpp_audio/ui/VoiceEditorDialog.cpp
+++ b/src/cpp_audio/ui/VoiceEditorDialog.cpp
@@ -2,6 +2,7 @@
 #include <juce_data_structures/juce_data_structures.h>
 #include <vector>
 
+#include "VoiceEditorDialog.h"
 using namespace juce;
 
 // Simple UI row with a label and a text editor used for both synth parameters

--- a/src/cpp_audio/ui/VoiceEditorDialog.h
+++ b/src/cpp_audio/ui/VoiceEditorDialog.h
@@ -1,0 +1,20 @@
+#pragma once
+#include <juce_core/juce_core.h>
+#include <vector>
+
+struct VoiceEditorDialog
+{
+    struct VoiceData
+    {
+        juce::String synthFunction;
+        bool isTransition = false;
+        juce::var params;
+        juce::var volumeEnvelope;
+        juce::String description;
+    };
+};
+
+VoiceEditorDialog::VoiceData showVoiceEditor(const juce::StringArray& synthNames,
+                                             const VoiceEditorDialog::VoiceData* existing = nullptr,
+                                             const std::vector<std::vector<VoiceEditorDialog::VoiceData>>* refSteps = nullptr,
+                                             bool* success = nullptr);


### PR DESCRIPTION
## Summary
- provide header for StepConfigPanel and move definitions into cpp
- add headers for various dialogs and theme utilities
- include these new headers in their cpp counterparts

## Testing
- `cmake -S . -B build` *(fails: JUCE subdirectory missing)*

------
https://chatgpt.com/codex/tasks/task_e_685c82d7bc30832db31778468c126ba9