### PR TITLE
Hook step selection to preview in JUCE GUI

### DIFF
--- a/src/cpp_audio/main.cpp
+++ b/src/cpp_audio/main.cpp
@@ -8,6 +8,7 @@
 #include "ui/GlobalSettingsComponent.h"
 #include "ui/StepListPanel.h"
 #include "ui/StepPreviewComponent.h"
+#include "Track.h"
 
 class MainComponent : public juce::Component
 {
@@ -19,6 +20,28 @@ public:
         addAndMakeVisible(settings);
         addAndMakeVisible(preview);
         addAndMakeVisible(stepList);
+        stepList.onStepSelected = [this](int index)
+        {
+            const auto& steps = stepList.getSteps();
+            if (juce::isPositiveAndBelow(index, steps.size()))
+            {
+                Step step;
+                step.durationSeconds = steps[index].duration;
+                step.description = steps[index].description;
+                auto gsRaw = settings.getSettings();
+                GlobalSettings gs;
+                gs.sampleRate = gsRaw.sampleRate;
+                gs.crossfadeDuration = gsRaw.crossfadeSeconds;
+                gs.outputFilename = gsRaw.outputFile;
+                gs.crossfadeCurve = "linear";
+                double previewDur = step.durationSeconds < 180.0 ? step.durationSeconds : 60.0;
+                preview.loadStep(step, gs, previewDur);
+            }
+            else
+            {
+                preview.reset();
+            }
+        };
         setSize (800, 600);
     }
 

--- a/src/cpp_audio/ui/StepListPanel.cpp
+++ b/src/cpp_audio/ui/StepListPanel.cpp
@@ -3,6 +3,7 @@
 #include <juce_core/juce_core.h>
 
 #include "../VarUtils.h"
+#include <functional>
 
 
 using namespace juce;
@@ -11,6 +12,7 @@ StepListPanel::StepListPanel()
 {
     addAndMakeVisible(stepList);
     stepList.setModel(this);
+    stepList.addListener(this);
 
     addButton.setButtonText("Add Step");
     loadButton.setButtonText("Load Steps");
@@ -77,6 +79,7 @@ StepListPanel::~StepListPanel()
                      &editDurationButton, &editDescriptionButton,
                      &upButton, &downButton, &undoButton, &redoButton })
         b->removeListener(this);
+    stepList.removeListener(this);
 }
 
 int StepListPanel::getNumRows()
@@ -353,5 +356,11 @@ bool StepListPanel::keyPressed(const KeyPress& key)
         return true;
     }
     return false;
+}
+
+void StepListPanel::selectedRowsChanged(int lastRowSelected)
+{
+    if (onStepSelected)
+        onStepSelected(lastRowSelected);
 }
 

--- a/src/cpp_audio/ui/StepListPanel.h
+++ b/src/cpp_audio/ui/StepListPanel.h
@@ -1,8 +1,10 @@
 #pragma once
 #include <juce_gui_basics/juce_gui_basics.h>
+#include <functional>
 
 class StepListPanel : public juce::Component,
                       private juce::ListBoxModel,
+                      private juce::ListBox::Listener,
                       private juce::Button::Listener
 {
 public:
@@ -19,6 +21,12 @@ public:
     void redo();
     bool canUndo() const;
     bool canRedo() const;
+
+    // Access steps and selection
+    const juce::Array<StepData>& getSteps() const { return steps; }
+    int getSelectedIndex() const { return stepList.getSelectedRow(); }
+
+    std::function<void(int)> onStepSelected;
 
 private:
     // UI components
@@ -49,4 +57,5 @@ private:
     void updateDuration();
     void pushHistory();
     void updateUndoRedoButtons();
+    void selectedRowsChanged(int lastRowSelected) override;
 };


### PR DESCRIPTION
## Summary
- expose step selection callbacks from `StepListPanel`
- update `main.cpp` to load a preview when a step is selected

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685c85fcce80832d93f77db08b62a319