### PR TITLE
Update VoiceEditorDialog header comment

### DIFF
--- a/src/cpp_audio/ui/VoiceEditorDialog.h
+++ b/src/cpp_audio/ui/VoiceEditorDialog.h
@@ -1,4 +1,12 @@
 #pragma once
+
+// VoiceEditorDialog.h
+// -------------------
+// Lightweight interface for launching the JUCE based voice editor.
+// This header exposes only the VoiceData structure along with a
+// helper function to open the modal dialog.  The dialog implementation
+// lives in VoiceEditorDialog.cpp to keep dependencies minimal.
+
 #include <juce_core/juce_core.h>
 #include <vector>
 


### PR DESCRIPTION
## Summary
- add short comment block explaining the purpose of `VoiceEditorDialog.h`

## Testing
- `cmake --preset=default` *(fails: JUCE directory missing)*
- `cmake --build --preset=default` *(fails: build.ninja missing)*

------
https://chatgpt.com/codex/tasks/task_e_685c8e6a5ff0832dbb822872511931ea