### PR TITLE
Add Noise Generator dialog to C++ GUI

### DIFF
--- a/src/cpp_audio/main.cpp
+++ b/src/cpp_audio/main.cpp
@@ -53,7 +53,7 @@ public:
     void resized() override
     {
         auto area = getLocalBounds().reduced (8);
-        settings.setBounds (area.removeFromTop (120));
+        settings.setBounds (area.removeFromTop (144));
         preview.setBounds(area.removeFromTop(80));
         stepList.setBounds (area);
     }

--- a/src/cpp_audio/ui/GlobalSettingsComponent.cpp
+++ b/src/cpp_audio/ui/GlobalSettingsComponent.cpp
@@ -1,4 +1,5 @@
 #include "GlobalSettingsComponent.h"
+#include "NoiseGeneratorDialog.h"
 
 using namespace juce;
 
@@ -30,12 +31,16 @@ GlobalSettingsComponent::GlobalSettingsComponent()
     noiseAmpLabel.setText("Noise Amp:", dontSendNotification);
     addAndMakeVisible(&noiseAmpEdit);
     noiseAmpEdit.setText("0.0");
+
+    addAndMakeVisible(&noiseGenButton);
+    noiseGenButton.addListener(this);
 }
 
 GlobalSettingsComponent::~GlobalSettingsComponent()
 {
     browseOutButton.removeListener(this);
     browseNoiseButton.removeListener(this);
+    noiseGenButton.removeListener(this);
 }
 
 GlobalSettingsComponent::Settings GlobalSettingsComponent::getSettings() const
@@ -86,6 +91,9 @@ void GlobalSettingsComponent::resized()
     row = area.removeFromTop(rowH);
     noiseAmpLabel.setBounds(row.removeFromLeft(labelW));
     noiseAmpEdit.setBounds(row);
+
+    row = area.removeFromTop(rowH);
+    noiseGenButton.setBounds(row);
 }
 
 void GlobalSettingsComponent::buttonClicked(Button* b)
@@ -101,6 +109,18 @@ void GlobalSettingsComponent::buttonClicked(Button* b)
         FileChooser chooser("Select Noise Preset", File(noiseFileEdit.getText()), "*.noise;*.wav");
         if (chooser.browseForFileToOpen())
             noiseFileEdit.setText(chooser.getResult().getFullPathName());
+    }
+    else if (b == &noiseGenButton)
+    {
+        auto dialog = createNoiseGeneratorDialog();
+        DialogWindow::LaunchOptions opts;
+        opts.content = std::move(dialog);
+        opts.dialogTitle = "Noise Generator";
+        opts.dialogBackgroundColour = Colours::lightgrey;
+        opts.escapeKeyTriggersCloseButton = true;
+        opts.useNativeTitleBar = true;
+        opts.resizable = true;
+        opts.runModal();
     }
 }
 

--- a/src/cpp_audio/ui/GlobalSettingsComponent.h
+++ b/src/cpp_audio/ui/GlobalSettingsComponent.h
@@ -28,4 +28,5 @@ private:
     juce::Label srLabel, cfLabel, outFileLabel, noiseFileLabel, noiseAmpLabel;
     juce::TextEditor srEdit, cfEdit, outFileEdit, noiseFileEdit, noiseAmpEdit;
     juce::TextButton browseOutButton {"Browse"}, browseNoiseButton {"Browse"};
+    juce::TextButton noiseGenButton {"Noise Generator"};
 };


### PR DESCRIPTION
## Summary
- expose the NoiseGeneratorDialog from the GlobalSettingsComponent
- adjust MainComponent layout for the new button
- wire button to launch the NoiseGeneratorDialog

## Testing
- `cmake --preset=default` *(fails: JUCE directory missing)*

------
https://chatgpt.com/codex/tasks/task_e_685ca76a7260832da6f2cf09af7d7c76