### PR TITLE
Integrate FrequencyTesterDialog in GUI

### DIFF
--- a/README_Audio.md
+++ b/README_Audio.md
@@ -73,6 +73,11 @@ duration adapts to the step length:
 This behaviour ensures that very long steps do not delay the preview yet short
 steps can still be heard in full.
 
+### Frequency Tester
+Use **Tools → Frequency Tester** to quickly audition up to ten binaural voices
+without creating a full track. Each voice allows custom base frequency, beat
+frequency, and amplitude using the current preference for absolute level or dB.
+
 ## C++ Port
 A minimal C++ implementation using JUCE lives in `src/cpp_audio`. Build it with CMake and ensure JUCE is available on your system. The GUI portion now resides under `src/cpp_audio/ui` and links directly to the same audio library to provide an integrated editor application.
 

--- a/src/audio/main.py
+++ b/src/audio/main.py
@@ -316,6 +316,23 @@ class TrackEditorApp(QMainWindow):
         self.redo_act.setShortcut("Ctrl+Y")
         self.redo_act.triggered.connect(self.redo)
         edit_menu.addAction(self.redo_act)
+
+        tools_menu = menubar.addMenu("Tools")
+        noise_act = QAction("Noise Generator", self)
+        noise_act.triggered.connect(self.open_noise_generator)
+        tools_menu.addAction(noise_act)
+
+        freq_test_act = QAction("Frequency Tester", self)
+        freq_test_act.triggered.connect(self.open_frequency_tester)
+        tools_menu.addAction(freq_test_act)
+
+        subliminal_act = QAction("Add Subliminal Voice", self)
+        subliminal_act.triggered.connect(self.open_subliminal_dialog)
+        tools_menu.addAction(subliminal_act)
+
+        timeline_act = QAction("View Timeline", self)
+        timeline_act.triggered.connect(self.open_timeline_visualizer)
+        tools_menu.addAction(timeline_act)
         self._update_undo_redo_actions_state()
 
 


### PR DESCRIPTION
## Summary
- add a Tools menu containing actions for Noise Generator, Frequency Tester, Subliminal Voice, and Timeline
- document Frequency Tester in README_Audio

## Testing
- `python -m py_compile src/audio/main.py src/audio/ui/frequency_tester_dialog.py`

------
https://chatgpt.com/codex/tasks/task_e_685caad2e418832da813e6027d4c5430