### PR TITLE
Add collapsible UI sections

### DIFF
--- a/src/audio/main.py
+++ b/src/audio/main.py
@@ -411,9 +411,9 @@ class TrackEditorApp(QMainWindow):
         main_layout.addWidget(vertical_splitter, 1)
 
         # Tool Buttons (Noise Generator, Frequency Tester, Subliminal Voice)
-        tools_groupbox = QGroupBox("Tools")
+        tools_groupbox = CollapsibleBox("Tools")
         tools_layout = QHBoxLayout()
-        tools_groupbox.setLayout(tools_layout)
+        tools_groupbox.setContentLayout(tools_layout)
         tools_left_layout = QVBoxLayout()
         tools_right_layout = QVBoxLayout()
         tools_layout.addLayout(tools_left_layout)
@@ -455,9 +455,9 @@ class TrackEditorApp(QMainWindow):
         control_layout.addWidget(tools_groupbox)
 
         # Global Settings
-        globals_groupbox = QGroupBox("Global Settings")
+        globals_groupbox = CollapsibleBox("Global Settings")
         globals_layout = QGridLayout()
-        globals_groupbox.setLayout(globals_layout)
+        globals_groupbox.setContentLayout(globals_layout)
         globals_layout.addWidget(QLabel("Sample Rate:"), 0, 0)
         self.sr_entry = QLineEdit(str(DEFAULT_SAMPLE_RATE))
         self.sr_entry.setValidator(self.int_validator_positive)
@@ -518,8 +518,9 @@ class TrackEditorApp(QMainWindow):
         steps_outer_layout = QVBoxLayout(steps_outer_widget)
         steps_outer_layout.setContentsMargins(0,0,0,0)
         main_splitter.addWidget(steps_outer_widget)
-        steps_groupbox = QGroupBox("Steps")
-        steps_groupbox_layout = QVBoxLayout(steps_groupbox)
+        steps_groupbox = CollapsibleBox("Steps")
+        steps_groupbox_layout = QVBoxLayout()
+        steps_groupbox.setContentLayout(steps_groupbox_layout)
         steps_outer_layout.addWidget(steps_groupbox)
         self.step_model = StepModel(self.track_data.get("steps", []))
         self.steps_tree = QTreeView()
@@ -616,9 +617,10 @@ class TrackEditorApp(QMainWindow):
         voices_outer_layout = QVBoxLayout(voices_outer_widget)
         voices_outer_layout.setContentsMargins(0,0,0,0)
         right_splitter.addWidget(voices_outer_widget)
-        self.voices_groupbox = QGroupBox("Voices for Selected Step")
+        self.voices_groupbox = CollapsibleBox("Voices for Selected Step")
         # Use an HBox layout so buttons can be stacked on the left side
-        voices_groupbox_layout = QHBoxLayout(self.voices_groupbox)
+        voices_groupbox_layout = QHBoxLayout()
+        self.voices_groupbox.setContentLayout(voices_groupbox_layout)
         voices_outer_layout.addWidget(self.voices_groupbox)
         self.voice_model = VoiceModel([])
         self.voices_tree = QTreeView()
@@ -668,8 +670,9 @@ class TrackEditorApp(QMainWindow):
         # Splitter to allow resizing between voice details and overlay clips
         details_splitter = QSplitter(Qt.Vertical)
         voice_details_outer_layout.addWidget(details_splitter)
-        self.voice_details_groupbox = QGroupBox("Selected Voice Details")
-        voice_details_groupbox_layout = QVBoxLayout(self.voice_details_groupbox)
+        self.voice_details_groupbox = CollapsibleBox("Selected Voice Details")
+        voice_details_groupbox_layout = QVBoxLayout()
+        self.voice_details_groupbox.setContentLayout(voice_details_groupbox_layout)
         details_splitter.addWidget(self.voice_details_groupbox)
         self.voice_details_text = QTextEdit()
         self.voice_details_text.setReadOnly(True)
@@ -678,9 +681,10 @@ class TrackEditorApp(QMainWindow):
         voice_details_groupbox_layout.addWidget(self.voice_details_text)
 
         # --- Overlay Clips Widgets ---
-        self.clips_groupbox = QGroupBox("Overlay Clips")
+        self.clips_groupbox = CollapsibleBox("Overlay Clips")
         # Layout with buttons stacked vertically on the left
-        clips_groupbox_layout = QHBoxLayout(self.clips_groupbox)
+        clips_groupbox_layout = QHBoxLayout()
+        self.clips_groupbox.setContentLayout(clips_groupbox_layout)
         details_splitter.addWidget(self.clips_groupbox)
 
         self.clips_tree = QTreeWidget()

--- a/src/audio/ui/collapsible_box.py
+++ b/src/audio/ui/collapsible_box.py
@@ -1,4 +1,4 @@
-from PyQt5.QtWidgets import QWidget, QToolButton, QVBoxLayout
+from PyQt5.QtWidgets import QWidget, QToolButton, QVBoxLayout, QLayout
 from PyQt5.QtCore import Qt
 
 class CollapsibleBox(QWidget):
@@ -25,6 +25,15 @@ class CollapsibleBox(QWidget):
         self.toggle_button.setArrowType(Qt.DownArrow if checked else Qt.RightArrow)
         self.content_area.setVisible(checked)
 
-    def setContentLayout(self, layout: QVBoxLayout):
+    def setContentLayout(self, layout: QLayout):
         """Set the layout that holds the collapsible content."""
         self.content_area.setLayout(layout)
+
+    # Convenience methods for compatibility with QGroupBox-like API
+    def setTitle(self, title: str) -> None:
+        """Set the title shown on the toggle button."""
+        self.toggle_button.setText(title)
+
+    def title(self) -> str:
+        """Return the current title text."""
+        return self.toggle_button.text()

--- a/src/audio/ui/preferences_dialog.py
+++ b/src/audio/ui/preferences_dialog.py
@@ -1,5 +1,5 @@
 from PyQt5.QtWidgets import (
-    QDialog, QVBoxLayout, QHBoxLayout, QFormLayout, QGroupBox,
+    QDialog, QVBoxLayout, QHBoxLayout, QFormLayout,
     QFontComboBox, QSpinBox, QDoubleSpinBox, QLineEdit, QPushButton,
     QFileDialog, QCheckBox, QComboBox, QDialogButtonBox, QLabel
 )
@@ -12,6 +12,7 @@ try:
 except ImportError:  # Running as a script without packages
     from utils.preferences import Preferences
 from . import themes  # reuse themes from audio package
+from .collapsible_box import CollapsibleBox
 
 class PreferencesDialog(QDialog):
     def __init__(self, prefs: Preferences, parent=None):
@@ -21,7 +22,7 @@ class PreferencesDialog(QDialog):
         layout = QVBoxLayout(self)
 
         # Font settings
-        font_group = QGroupBox("Font")
+        font_group = CollapsibleBox("Font")
         form = QFormLayout()
         self.font_combo = QFontComboBox()
         if prefs.font_family:
@@ -31,11 +32,11 @@ class PreferencesDialog(QDialog):
         self.font_size_spin.setValue(prefs.font_size)
         form.addRow("Family:", self.font_combo)
         form.addRow("Size:", self.font_size_spin)
-        font_group.setLayout(form)
+        font_group.setContentLayout(form)
         layout.addWidget(font_group)
 
         # Theme
-        theme_group = QGroupBox("Theme")
+        theme_group = CollapsibleBox("Theme")
         theme_layout = QHBoxLayout()
         self.theme_combo = QComboBox()
         self.theme_combo.addItems(themes.THEMES.keys())
@@ -44,22 +45,22 @@ class PreferencesDialog(QDialog):
             self.theme_combo.setCurrentIndex(idx)
         theme_layout.addWidget(QLabel("Theme:"))
         theme_layout.addWidget(self.theme_combo)
-        theme_group.setLayout(theme_layout)
+        theme_group.setContentLayout(theme_layout)
         layout.addWidget(theme_group)
 
         # Export directory
-        export_group = QGroupBox("Export")
+        export_group = CollapsibleBox("Export")
         export_layout = QHBoxLayout()
         self.export_edit = QLineEdit(prefs.export_dir)
         browse_btn = QPushButton("Browse")
         browse_btn.clicked.connect(self.browse_dir)
         export_layout.addWidget(self.export_edit)
         export_layout.addWidget(browse_btn)
-        export_group.setLayout(export_layout)
+        export_group.setContentLayout(export_layout)
         layout.addWidget(export_group)
 
         # Sample rate, test step duration, and target amplitude
-        audio_group = QGroupBox("Audio/Test")
+        audio_group = CollapsibleBox("Audio/Test")
         audio_form = QFormLayout()
         self.sample_rate_spin = QSpinBox()
         self.sample_rate_spin.setRange(8000, 192000)
@@ -105,7 +106,7 @@ class PreferencesDialog(QDialog):
         audio_form.addRow("Crossfade Curve:", self.crossfade_curve_combo)
         audio_form.addRow(self.track_metadata_chk)
         audio_form.addRow(self.apply_target_amp_chk)
-        audio_group.setLayout(audio_form)
+        audio_group.setContentLayout(audio_form)
         layout.addWidget(audio_group)
 
         # Buttons


### PR DESCRIPTION
## Summary
- extend `CollapsibleBox` with QGroupBox-like helpers
- use `CollapsibleBox` in Preferences dialog
- convert many group boxes in the main window to collapsible ones

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685caadb004c832d8a22f3411f80ae2d