### PR TITLE
Integrate StepPreviewComponent into GUI

### DIFF
--- a/src/audio/main.py
+++ b/src/audio/main.py
@@ -63,6 +63,7 @@ from ui.subliminal_dialog import SubliminalDialog
 from utils.timeline_visualizer import visualize_track_timeline
 from ui.overlay_clip_dialog import OverlayClipDialog
 from ui.collapsible_box import CollapsibleBox
+from ui.step_preview_component import StepPreviewComponent
 from models import StepModel, VoiceModel
 
 # Attempt to import VoiceEditorDialog. Handle if ui/voice_editor_dialog.py is not found.
@@ -573,38 +574,22 @@ class TrackEditorApp(QMainWindow):
         steps_groupbox_layout.addLayout(steps_button_layout_2)
 
         # --- Test Step Preview Section ---
-        test_step_groupbox = QGroupBox("Test Step Preview")
-        test_step_main_layout = QVBoxLayout(test_step_groupbox)
+        self.step_preview = StepPreviewComponent()
+        steps_groupbox_layout.addWidget(self.step_preview)
 
-        test_controls_top_layout = QHBoxLayout() # For buttons
-        self.test_step_play_pause_button = QPushButton("Play")
-        self.test_step_play_pause_button.clicked.connect(self.on_play_pause_step_test)
-        test_controls_top_layout.addWidget(self.test_step_play_pause_button)
+        # Maintain existing attribute names for compatibility
+        self.test_step_play_pause_button = self.step_preview.play_pause_button
+        self.test_step_stop_button = self.step_preview.stop_button
+        self.test_step_reset_button = self.step_preview.reset_button
+        self.test_step_loaded_label = self.step_preview.loaded_label
+        self.test_step_time_slider = self.step_preview.time_slider
+        self.test_step_time_label = self.step_preview.time_label
 
-        self.test_step_stop_button = QPushButton("Stop")
-        self.test_step_stop_button.clicked.connect(self.on_stop_step_test) # Connect to the base on_stop_step_test
-        test_controls_top_layout.addWidget(self.test_step_stop_button)
-
-        self.test_step_reset_button = QPushButton("Reset Tester") # New button
-        self.test_step_reset_button.clicked.connect(self.on_reset_step_test)
-        test_controls_top_layout.addWidget(self.test_step_reset_button)
-        test_controls_top_layout.addStretch()
-        test_step_main_layout.addLayout(test_controls_top_layout)
-
-        self.test_step_loaded_label = QLabel("No step loaded for preview.") # New label
-        self.test_step_loaded_label.setWordWrap(True)
-        self.test_step_loaded_label.setAlignment(Qt.AlignCenter) 
-        test_step_main_layout.addWidget(self.test_step_loaded_label)
-
-        self.test_step_time_slider = QSlider(Qt.Horizontal)
-        self.test_step_time_slider.sliderMoved.connect(self.on_test_slider_moved)
-        self.test_step_time_slider.sliderReleased.connect(self.on_test_slider_released)
-        test_step_main_layout.addWidget(self.test_step_time_slider)
-
-        self.test_step_time_label = QLabel("00:00 / 00:00")
-        self.test_step_time_label.setAlignment(Qt.AlignCenter)
-        test_step_main_layout.addWidget(self.test_step_time_label)
-        steps_groupbox_layout.addWidget(test_step_groupbox)
+        self.step_preview.play_pause_button.clicked.connect(self.on_play_pause_step_test)
+        self.step_preview.stop_button.clicked.connect(self.on_stop_step_test)
+        self.step_preview.reset_button.clicked.connect(self.on_reset_step_test)
+        self.step_preview.time_slider.sliderMoved.connect(self.on_test_slider_moved)
+        self.step_preview.time_slider.sliderReleased.connect(self.on_test_slider_released)
 
 
         # --- Right Pane (Splitter) ---

--- a/src/audio/ui/step_preview_component.py
+++ b/src/audio/ui/step_preview_component.py
@@ -1,0 +1,45 @@
+from PyQt5.QtWidgets import (
+    QGroupBox, QVBoxLayout, QHBoxLayout,
+    QPushButton, QLabel, QSlider
+)
+from PyQt5.QtCore import Qt
+
+
+class StepPreviewComponent(QGroupBox):
+    """Reusable widget for previewing a single step."""
+
+    def __init__(self, parent=None):
+        super().__init__("Test Step Preview", parent)
+
+        layout = QVBoxLayout(self)
+
+        controls_layout = QHBoxLayout()
+        self.play_pause_button = QPushButton("Play")
+        self.stop_button = QPushButton("Stop")
+        self.reset_button = QPushButton("Reset Tester")
+
+        controls_layout.addWidget(self.play_pause_button)
+        controls_layout.addWidget(self.stop_button)
+        controls_layout.addWidget(self.reset_button)
+        controls_layout.addStretch()
+        layout.addLayout(controls_layout)
+
+        self.loaded_label = QLabel("No step loaded for preview.")
+        self.loaded_label.setWordWrap(True)
+        self.loaded_label.setAlignment(Qt.AlignCenter)
+        layout.addWidget(self.loaded_label)
+
+        self.time_slider = QSlider(Qt.Horizontal)
+        layout.addWidget(self.time_slider)
+
+        self.time_label = QLabel("00:00 / 00:00")
+        self.time_label.setAlignment(Qt.AlignCenter)
+        layout.addWidget(self.time_label)
+
+    def reset(self):
+        """Restore default UI state."""
+        self.play_pause_button.setText("Play")
+        self.time_slider.setRange(0, 1)
+        self.time_slider.setValue(0)
+        self.time_label.setText("00:00 / 00:00")
+        self.loaded_label.setText("No step loaded for preview.")


### PR DESCRIPTION
## Summary
- add a reusable `StepPreviewComponent` widget
- integrate it into the Qt-based audio GUI

## Testing
- `python3 -m py_compile src/audio/ui/step_preview_component.py src/audio/main.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685caaf99294832dadca2dd19b12485a