### PR TITLE
Fix noise generator dialog creation

### DIFF
--- a/src/cpp_audio/ui/GlobalSettingsComponent.cpp
+++ b/src/cpp_audio/ui/GlobalSettingsComponent.cpp
@@ -123,6 +123,7 @@ void GlobalSettingsComponent::buttonClicked(Button *b) {
     if (chooser.browseForFileToOpen())
       noiseFileEdit.setText(chooser.getResult().getFullPathName());
   } else if (b == &noiseGenButton) {
+    auto dialog = createNoiseGeneratorDialog();
     DialogWindow::LaunchOptions opts;
 
     opts.content.setOwned(dialog.release());


### PR DESCRIPTION
## Summary
- reintroduce the missing `createNoiseGeneratorDialog()` call

## Testing
- `cmake --preset=default` *(fails: JUCE directory missing)*

------
https://chatgpt.com/codex/tasks/task_e_685db481b6ac832db8020c22bd7fefee