### PR TITLE
Add voice editing via StepListPanel

### DIFF
--- a/src/cpp_audio/main.cpp
+++ b/src/cpp_audio/main.cpp
@@ -28,6 +28,16 @@ public:
                 Step step;
                 step.durationSeconds = steps[index].duration;
                 step.description = steps[index].description;
+                for (const auto& vd : steps[index].voices)
+                {
+                    Voice v;
+                    v.synthFunction = vd.synthFunction.toStdString();
+                    if (auto* obj = vd.params.getDynamicObject())
+                        v.params = obj->getProperties();
+                    v.isTransition = vd.isTransition;
+                    v.description = vd.description;
+                    step.voices.push_back(std::move(v));
+                }
                 auto gsRaw = settings.getSettings();
                 GlobalSettings gs;
                 gs.sampleRate = gsRaw.sampleRate;

--- a/src/cpp_audio/ui/StepConfigPanel.h
+++ b/src/cpp_audio/ui/StepConfigPanel.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <juce_gui_basics/juce_gui_basics.h>
+#include "VoiceEditorDialog.h"
 
 class StepConfigPanel : public juce::Component,
                         private juce::ListBoxModel,
@@ -13,10 +14,15 @@ public:
     void paintListBoxItem(int row, juce::Graphics&, int width, int height, bool selected) override;
     void resized() override;
 
+    void setVoices(const juce::Array<VoiceEditorDialog::VoiceData>& v);
+    juce::Array<VoiceEditorDialog::VoiceData> getVoices() const;
+
+    std::function<void()> onVoicesChanged;
+
 private:
     juce::ListBox voiceList;
     juce::TextButton addButton, dupButton, removeButton, editButton, upButton, downButton;
-    juce::StringArray voices;
+    juce::Array<VoiceEditorDialog::VoiceData> voices;
 
     void buttonClicked(juce::Button*) override;
     void addVoice();

--- a/src/cpp_audio/ui/StepListPanel.h
+++ b/src/cpp_audio/ui/StepListPanel.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <functional>
 #include <juce_gui_basics/juce_gui_basics.h>
+#include "StepConfigPanel.h"
 
 class StepListPanel : public juce::Component,
                       private juce::ListBoxModel,
@@ -10,6 +11,7 @@ public:
   struct StepData {
     juce::String description{"New Step"};
     double duration{10.0};
+    juce::Array<VoiceEditorDialog::VoiceData> voices;
   };
 
   StepListPanel();
@@ -37,8 +39,8 @@ private:
   // UI components
   juce::ListBox stepList;
   juce::TextButton addButton, loadButton, dupButton, removeButton,
-      editDurationButton, editDescriptionButton, upButton, downButton,
-      undoButton, redoButton;
+      editDurationButton, editDescriptionButton, editVoicesButton, upButton,
+      downButton, undoButton, redoButton;
   juce::Label totalDuration;
 
   juce::Array<StepData> steps;
@@ -51,6 +53,7 @@ private:
   void duplicateStep();
   void removeStep();
   void moveStep(int delta);
+  void openStepConfig();
   void editStepDuration();
   void editStepDescription();
   void updateDuration();


### PR DESCRIPTION
## Summary
- allow steps to hold `VoiceData` and expose an `Edit Voices` button
- implement StepConfigPanel setters/getters for voices
- parse voices when loading external step JSON
- pass selected step voices to preview

## Testing
- `cmake --preset default` *(fails: JUCE directory missing)*

------
https://chatgpt.com/codex/tasks/task_e_685db95e94f0832daa4aaf41c16698e5