### PR TITLE
Implement stub simulator window

### DIFF
--- a/src/audio/ui/__init__.py
+++ b/src/audio/ui/__init__.py
@@ -1,1 +1,3 @@
 from .frequency_tester_dialog import FrequencyTesterDialog
+
+from .simulator import SimulatorWindow

--- a/src/audio/ui/simulator.py
+++ b/src/audio/ui/simulator.py
@@ -1,0 +1,21 @@
+from PyQt5.QtWidgets import QMainWindow, QWidget, QVBoxLayout, QLabel, QPushButton
+from PyQt5.QtCore import Qt
+
+
+class SimulatorWindow(QMainWindow):
+    """Simple placeholder simulator window."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("Simulator (Placeholder)")
+        central = QWidget()
+        self.setCentralWidget(central)
+        layout = QVBoxLayout(central)
+
+        label = QLabel("Simulator is not yet implemented.")
+        label.setAlignment(Qt.AlignCenter)
+        layout.addWidget(label)
+
+        close_btn = QPushButton("Close")
+        close_btn.clicked.connect(self.close)
+        layout.addWidget(close_btn, alignment=Qt.AlignCenter)


### PR DESCRIPTION
## Summary
- implement a simple placeholder SimulatorWindow
- expose SimulatorWindow from audio ui package
- link from the editor using existing button and menu

## Testing
- `python -m py_compile src/audio/ui/simulator.py`
- `python -m py_compile src/audio/ui/__init__.py src/audio/main.py`


------
https://chatgpt.com/codex/tasks/task_e_685db98463cc832daa3f6cd95204b1f6