### PR TITLE
Integrate theme into C++ preferences

### DIFF
--- a/src/cpp_audio/main.cpp
+++ b/src/cpp_audio/main.cpp
@@ -9,6 +9,8 @@
 #include "ui/StepListPanel.h"
 #include "ui/StepPreviewComponent.h"
 #include "Track.h"
+#include "ui/PreferencesDialog.h"
+#include "ui/Themes.h"
 
 class MainComponent : public juce::Component
 {
@@ -95,13 +97,19 @@ public:
 
     void initialise (const juce::String&) override
     {
+        juce::Desktop::getInstance().setDefaultLookAndFeel(&lookAndFeel);
+        applyTheme(lookAndFeel, prefs.theme);
         mainWindow.reset(new MainWindow(getApplicationName()));
+        showPreferencesDialog(prefs);
+        applyTheme(lookAndFeel, prefs.theme);
     }
 
     void shutdown() override { mainWindow = nullptr; }
 
 private:
     std::unique_ptr<MainWindow> mainWindow;
+    juce::LookAndFeel_V4 lookAndFeel;
+    Preferences prefs;
 };
 
 START_JUCE_APPLICATION(AudioApplication)

--- a/src/cpp_audio/ui/PreferencesDialog.cpp
+++ b/src/cpp_audio/ui/PreferencesDialog.cpp
@@ -2,6 +2,7 @@
 #include <juce_gui_extra/juce_gui_extra.h>
 #include <cmath>
 #include "Preferences.h"
+#include "Themes.h"
 #include "PreferencesDialog.h"
 
 using namespace juce;
@@ -297,6 +298,8 @@ bool showPreferencesDialog (Preferences& prefs)
     if (result != 0 && dialog.wasAccepted())
     {
         prefs = dialog.getPreferences();
+        if (auto* lf = dynamic_cast<LookAndFeel_V4*>(&Desktop::getInstance().getDefaultLookAndFeel()))
+            applyTheme(*lf, prefs.theme);
         return true;
     }
     return false;


### PR DESCRIPTION
## Summary
- integrate theme application when preferences are changed
- apply stored theme during application startup
- prompt user for preferences on launch

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `cmake -B build -S .` *(fails: JUCE missing)*

------
https://chatgpt.com/codex/tasks/task_e_685db98e00a0832d80aade3496a8a7e8