### PR TITLE
Enable frequency tester dialog

### DIFF
--- a/src/cpp_audio/main.cpp
+++ b/src/cpp_audio/main.cpp
@@ -16,7 +16,8 @@ class MainComponent : public juce::Component
 {
 public:
     MainComponent()
-        : preview(deviceManager)
+        : settings(deviceManager),
+          preview(deviceManager)
     {
         deviceManager.initialise(0, 2, nullptr, true);
         addAndMakeVisible(settings);

--- a/src/cpp_audio/ui/GlobalSettingsComponent.cpp
+++ b/src/cpp_audio/ui/GlobalSettingsComponent.cpp
@@ -1,6 +1,7 @@
 
 #include "GlobalSettingsComponent.h"
 #include "NoiseGeneratorDialog.h" // Include the full dialog implementation here
+#include "FrequencyTesterDialog.h"
 
 using namespace juce;
 
@@ -12,7 +13,8 @@ GlobalSettingsComponent::createNoiseGeneratorDialog() {
   return std::make_unique<NoiseGeneratorDialog>();
 }
 
-GlobalSettingsComponent::GlobalSettingsComponent() {
+GlobalSettingsComponent::GlobalSettingsComponent(juce::AudioDeviceManager& dm)
+    : deviceManager(dm) {
   addAndMakeVisible(&srLabel);
   srLabel.setText("Sample Rate:", dontSendNotification);
   addAndMakeVisible(&srEdit);
@@ -45,12 +47,17 @@ GlobalSettingsComponent::GlobalSettingsComponent() {
   addAndMakeVisible(&noiseGenButton);
   noiseGenButton.setButtonText("Generate Noise Preset...");
   noiseGenButton.addListener(this);
+
+  addAndMakeVisible(&freqTestButton);
+  freqTestButton.setButtonText("Frequency Test...");
+  freqTestButton.addListener(this);
 }
 
 GlobalSettingsComponent::~GlobalSettingsComponent() {
   browseOutButton.removeListener(this);
   browseNoiseButton.removeListener(this);
   noiseGenButton.removeListener(this);
+  freqTestButton.removeListener(this);
 }
 
 GlobalSettingsComponent::Settings GlobalSettingsComponent::getSettings() const {
@@ -109,6 +116,7 @@ void GlobalSettingsComponent::resized() {
   noiseAmpEdit.setBounds(row5);
 
   noiseGenButton.setBounds(area.removeFromTop(rowH));
+  freqTestButton.setBounds(area.removeFromTop(rowH));
 }
 
 void GlobalSettingsComponent::buttonClicked(Button *b) {
@@ -128,6 +136,16 @@ void GlobalSettingsComponent::buttonClicked(Button *b) {
 
     opts.content.setOwned(dialog.release());
     opts.dialogTitle = "Noise Generator";
+    opts.dialogBackgroundColour = Colours::lightgrey;
+    opts.escapeKeyTriggersCloseButton = true;
+    opts.useNativeTitleBar = true;
+    opts.resizable = true;
+    opts.runModal();
+  } else if (b == &freqTestButton) {
+    auto dialog = createFrequencyTesterDialog(deviceManager);
+    DialogWindow::LaunchOptions opts;
+    opts.content.setOwned(dialog.release());
+    opts.dialogTitle = "Frequency Test";
     opts.dialogBackgroundColour = Colours::lightgrey;
     opts.escapeKeyTriggersCloseButton = true;
     opts.useNativeTitleBar = true;

--- a/src/cpp_audio/ui/GlobalSettingsComponent.h
+++ b/src/cpp_audio/ui/GlobalSettingsComponent.h
@@ -2,6 +2,7 @@
 #pragma once
 
 #include <juce_gui_basics/juce_gui_basics.h>
+#include <juce_audio_devices/juce_audio_devices.h>
 #include <memory> // For std::unique_ptr
 
 // Forward declaration to avoid including the full dialog header here.
@@ -18,7 +19,7 @@ public:
     double noiseAmp = 0.0;
   };
 
-  GlobalSettingsComponent();
+  explicit GlobalSettingsComponent(juce::AudioDeviceManager& dm);
   ~GlobalSettingsComponent() override;
 
   Settings getSettings() const;
@@ -31,9 +32,12 @@ private:
   // A helper function to create the dialog.
   std::unique_ptr<NoiseGeneratorDialog> createNoiseGeneratorDialog();
 
+  juce::AudioDeviceManager& deviceManager;
+
   juce::Label srLabel, cfLabel, outFileLabel, noiseFileLabel, noiseAmpLabel;
   juce::TextEditor srEdit, cfEdit, outFileEdit, noiseFileEdit, noiseAmpEdit;
-  juce::TextButton browseOutButton, browseNoiseButton, noiseGenButton;
+  juce::TextButton browseOutButton, browseNoiseButton, noiseGenButton,
+      freqTestButton;
 
   JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR(GlobalSettingsComponent)
 };


### PR DESCRIPTION
## Summary
- wire the device manager through GlobalSettingsComponent so dialogs can play audio
- add a `Frequency Test...` button that launches `FrequencyTesterDialog`
- initialize GlobalSettingsComponent with the audio device manager

## Testing
- `cmake --preset=default` *(fails: JUCE missing)*

------
https://chatgpt.com/codex/tasks/task_e_685dd65eac30832d9b53817afaa77391