### PR TITLE
Fix JUCE modal loop flag

### DIFF
--- a/src/cpp_audio/CMakeLists.txt
+++ b/src/cpp_audio/CMakeLists.txt
@@ -81,14 +81,7 @@ target_link_libraries(AudioApp
         # add other juce::<module> targets as needed
 )
 
-<<<<<<< abcd/fix-missing-runmodal-functions-in-juce-dialog-components
-# Ensure modal loop APIs like runModal and runModalLoop are available
-# for our dialogs when building this standalone target.
-=======
-# JUCE's synchronous FileChooser methods are disabled unless this
-# definition is enabled. Some UI components still rely on functions like
-# browseForFileToOpen(), so enable modal loops explicitly.
->>>>>>> main
+# Enable synchronous modal dialogs (runModal, runModalLoop, FileChooser APIs)
 target_compile_definitions(AudioApp PRIVATE JUCE_MODAL_LOOPS_PERMITTED=1)
 
 


### PR DESCRIPTION
## Summary
- clean merge markers from the C++ audio CMakeLists
- ensure JUCE_MODAL_LOOPS_PERMITTED is always defined

## Testing
- `python -m compileall -q src/audio`
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release` *(fails: JUCE directory missing)*

------
https://chatgpt.com/codex/tasks/task_e_685dec2f76ac832dbeffa2925bd577b8