### PR TITLE
Add overlay clip editing support

### DIFF
--- a/src/cpp_audio/main.cpp
+++ b/src/cpp_audio/main.cpp
@@ -7,10 +7,12 @@
 
 #include "ui/GlobalSettingsComponent.h"
 #include "ui/StepListPanel.h"
+#include "ui/OverlayClipPanel.h"
 #include "ui/StepPreviewComponent.h"
 #include "Track.h"
 #include "ui/PreferencesDialog.h"
 #include "ui/Themes.h"
+#include <vector>
 
 class MainComponent : public juce::Component
 {
@@ -22,6 +24,8 @@ public:
         addAndMakeVisible(settings);
         addAndMakeVisible(preview);
         addAndMakeVisible(stepList);
+        addAndMakeVisible(editClipsButton);
+        editClipsButton.onClick = [this] { openClipEditor(); };
         stepList.onStepSelected = [this](int index)
         {
             const auto& steps = stepList.getSteps();
@@ -67,6 +71,8 @@ public:
         auto area = getLocalBounds().reduced (8);
         settings.setBounds (area.removeFromTop (144));
         preview.setBounds(area.removeFromTop(80));
+        editClipsButton.setBounds(area.removeFromTop(24));
+        area.removeFromTop(4);
         stepList.setBounds (area);
     }
 
@@ -75,6 +81,24 @@ private:
     GlobalSettingsComponent settings;
     StepPreviewComponent preview;
     StepListPanel stepList;
+    juce::TextButton editClipsButton {"Overlay Clips..."};
+    std::vector<OverlayClipPanel::ClipData> clips;
+
+    void openClipEditor()
+    {
+        auto* panel = new OverlayClipPanel();
+        panel->setClips(clips);
+        panel->onClipsChanged = [this, panel]() { clips = panel->getClips(); };
+
+        juce::DialogWindow::LaunchOptions opts;
+        opts.content.setOwned(panel);
+        opts.dialogTitle = "Overlay Clips";
+        opts.dialogBackgroundColour = juce::Colours::lightgrey;
+        opts.escapeKeyTriggersCloseButton = true;
+        opts.useNativeTitleBar = true;
+        opts.resizable = true;
+        opts.runModal();
+    }
 };
 
 class MainWindow : public juce::DocumentWindow

--- a/src/cpp_audio/ui/OverlayClipPanel.cpp
+++ b/src/cpp_audio/ui/OverlayClipPanel.cpp
@@ -57,6 +57,18 @@ void OverlayClipPanel::resized()
     playButton.setBounds(buttons);
 }
 
+void OverlayClipPanel::setClips(const std::vector<ClipData>& c)
+{
+    clips = c;
+    clipList.updateContent();
+    clipList.repaint();
+}
+
+std::vector<OverlayClipPanel::ClipData> OverlayClipPanel::getClips() const
+{
+    return clips;
+}
+
 void OverlayClipPanel::buttonClicked(juce::Button* b)
 {
     if (b == &addButton)
@@ -83,6 +95,8 @@ void OverlayClipPanel::addClip()
         clips.push_back(data);
         clipList.updateContent();
         clipList.selectRow((int)clips.size() - 1);
+        if (onClipsChanged)
+            onClipsChanged();
     }
 }
 
@@ -97,6 +111,8 @@ void OverlayClipPanel::editClip()
     {
         clips[(size_t)row] = data;
         clipList.repaintRow(row);
+        if (onClipsChanged)
+            onClipsChanged();
     }
 }
 
@@ -107,6 +123,8 @@ void OverlayClipPanel::removeClip()
         return;
     clips.erase(clips.begin() + row);
     clipList.updateContent();
+    if (onClipsChanged)
+        onClipsChanged();
 }
 
 void OverlayClipPanel::startPlayback()

--- a/src/cpp_audio/ui/OverlayClipPanel.h
+++ b/src/cpp_audio/ui/OverlayClipPanel.h
@@ -3,6 +3,8 @@
 #include <juce_audio_devices/juce_audio_devices.h>
 #include <juce_audio_formats/juce_audio_formats.h>
 #include <juce_audio_utils/juce_audio_utils.h>
+#include <functional>
+#include <vector>
 #include "OverlayClipDialog.h"
 
 class OverlayClipPanel : public juce::Component,
@@ -13,9 +15,16 @@ public:
     OverlayClipPanel();
     ~OverlayClipPanel() override;
 
+    using ClipData = OverlayClipDialog::ClipData;
+
     int getNumRows() override;
     void paintListBoxItem(int row, juce::Graphics& g, int width, int height, bool rowIsSelected) override;
     void resized() override;
+
+    void setClips(const std::vector<ClipData>& c);
+    std::vector<ClipData> getClips() const;
+
+    std::function<void()> onClipsChanged;
 
 private:
     void buttonClicked(juce::Button*) override;
@@ -37,5 +46,5 @@ private:
     juce::AudioSourcePlayer sourcePlayer;
     std::unique_ptr<juce::AudioFormatReaderSource> readerSource;
 
-    std::vector<OverlayClipDialog::ClipData> clips;
+    std::vector<ClipData> clips;
 };


### PR DESCRIPTION
## Summary
- expose overlay clip editing panel
- add hook in main component to open the panel
- provide setters/getters for clip data and callback for changes

## Testing
- `cmake --preset=default` *(fails: JUCE directory missing)*

------
https://chatgpt.com/codex/tasks/task_e_685deba27e24832d958086276ca383e9