### PR TITLE
Fix stack-owned dialogs crash

### DIFF
--- a/src/cpp_audio/ui/OverlayClipDialog.cpp
+++ b/src/cpp_audio/ui/OverlayClipDialog.cpp
@@ -299,7 +299,7 @@ OverlayClipDialog::ClipData showOverlayClipEditor(bool amplitudeInDb,
 {
     OverlayClipDialogWindow dialog(amplitudeInDb, existing);
     juce::DialogWindow::LaunchOptions opts;
-    opts.content.setOwned(&dialog);
+    opts.content.setNonOwned(&dialog);
     opts.dialogTitle = "Overlay Clip";
     opts.dialogBackgroundColour = juce::Colours::lightgrey;
     opts.escapeKeyTriggersCloseButton = true;

--- a/src/cpp_audio/ui/PreferencesDialog.cpp
+++ b/src/cpp_audio/ui/PreferencesDialog.cpp
@@ -303,7 +303,7 @@ bool showPreferencesDialog (Preferences& prefs)
 {
     PreferencesDialog dialog (prefs);
     DialogWindow::LaunchOptions opts;
-    opts.content.setOwned (&dialog);
+    opts.content.setNonOwned (&dialog);
     opts.dialogTitle = "Preferences";
     opts.dialogBackgroundColour = Colours::lightgrey;
     opts.escapeKeyTriggersCloseButton = true;


### PR DESCRIPTION
## Summary
- prevent dialogs from taking ownership of stack-allocated components
- fix overlay clip editor and preferences dialog crash

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685dfd0b5d28832d8bdb168e48a6f183