### PR TITLE
Update cpp_audio CMake for cross-platform GUI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,7 +82,18 @@ set(SOURCES
 #--------------------------------------------------
 # 3) Create the executable
 #--------------------------------------------------
-add_executable(AudioApp WIN32 ${SOURCES})
+# Build a GUI executable. The WIN32 keyword hides the console window on
+# Windows. On Linux it has no effect but is harmless, so we only use it
+# when running on Windows.
+if(WIN32)
+    add_executable(AudioApp WIN32 ${SOURCES})
+    target_compile_definitions(AudioApp PRIVATE PLATFORM_WINDOWS=1)
+elseif(UNIX AND NOT APPLE)
+    add_executable(AudioApp ${SOURCES})
+    target_compile_definitions(AudioApp PRIVATE PLATFORM_LINUX=1)
+else()
+    add_executable(AudioApp ${SOURCES})
+endif()
 
 # Include headers from your code tree
 target_include_directories(AudioApp

--- a/src/cpp_audio/CMakeLists.txt
+++ b/src/cpp_audio/CMakeLists.txt
@@ -56,12 +56,26 @@ set(SOURCES
 # ----------------------------------------
 # 3) Define the executable target
 # ----------------------------------------
-add_executable(AudioApp ${SOURCES})
+# Create a GUI executable on all platforms. The WIN32 keyword prevents a
+# console window from appearing on Windows, while it has no effect on
+# Linux. This lets the same project file work for both operating systems.
+if(WIN32)
+    add_executable(AudioApp WIN32 ${SOURCES})
+else()
+    add_executable(AudioApp ${SOURCES})
+endif()
 
 target_include_directories(AudioApp
     PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}
 )
+
+# Platform specific defines
+if(WIN32)
+    target_compile_definitions(AudioApp PRIVATE PLATFORM_WINDOWS=1)
+elseif(UNIX AND NOT APPLE)
+    target_compile_definitions(AudioApp PRIVATE PLATFORM_LINUX=1)
+endif()
 
 # ----------------------------------------
 # 4) Link JUCE modules


### PR DESCRIPTION
## Summary
- update root `CMakeLists.txt` to detect Windows vs Linux and set platform macros
- update `src/cpp_audio/CMakeLists.txt` with matching logic and improved comments

## Testing
- `cmake -S src/cpp_audio -B build_cpp_audio` *(fails: JUCE directory missing)*
- `cmake -S . -B build` *(fails: JUCE directory missing)*

------
https://chatgpt.com/codex/tasks/task_e_685dfeab82e0832d9cff7572bb70f740