### PR TITLE
Fix audio callback cleanup in StepPreviewer

### DIFF
--- a/src/cpp_audio/StepPreviewer.cpp
+++ b/src/cpp_audio/StepPreviewer.cpp
@@ -7,6 +7,14 @@ StepPreviewer::StepPreviewer(juce::AudioDeviceManager& dm)
     player->setSource(&transport);
 }
 
+StepPreviewer::~StepPreviewer()
+{
+    if (playing)
+        deviceManager.removeAudioCallback(player.get());
+    player->setSource(nullptr);
+    transport.setSource(nullptr);
+}
+
 bool StepPreviewer::loadStep(const Step& step, const GlobalSettings& settings, double previewDuration)
 {
     sampleRate = settings.sampleRate;

--- a/src/cpp_audio/StepPreviewer.h
+++ b/src/cpp_audio/StepPreviewer.h
@@ -7,6 +7,7 @@ class StepPreviewer
 {
 public:
     explicit StepPreviewer(juce::AudioDeviceManager& dm);
+    ~StepPreviewer();
 
     bool loadStep(const Step& step, const GlobalSettings& settings, double previewDuration);
 


### PR DESCRIPTION
## Summary
- ensure StepPreviewer removes its audio callback when destroyed

## Testing
- `cmake --preset default` *(fails: JUCE directory missing)*

------
https://chatgpt.com/codex/tasks/task_e_685ea88a3200832d9429354f0631526e