### PR TITLE
Remove duplicate calculateTransitionAlpha

### DIFF
--- a/src/cpp_audio/Common.cpp
+++ b/src/cpp_audio/Common.cpp
@@ -397,37 +397,3 @@ std::vector<double> applyFilters(const std::vector<double>& signalSegment,
     return result;
 }
 
-std::vector<double> calculateTransitionAlpha(double totalDuration,
-                                             double sampleRate,
-                                             double initialOffset,
-                                             double postOffset,
-                                             const std::string& curve)
-{
-    int N = static_cast<int>(totalDuration * sampleRate);
-    std::vector<double> alpha(N, 0.0);
-    if (N <= 0)
-        return alpha;
-
-    double startT = std::min(initialOffset, totalDuration);
-    double endT = std::max(startT, totalDuration - postOffset);
-    double transTime = endT - startT;
-
-    for (int i = 0; i < N; ++i)
-    {
-        double t = static_cast<double>(i) / sampleRate;
-        double a = 0.0;
-        if (transTime > 0.0)
-        {
-            a = (t - startT) / transTime;
-            a = std::clamp(a, 0.0, 1.0);
-        }
-
-        if (curve == "logarithmic")
-            a = 1.0 - std::pow(1.0 - a, 2.0);
-        else if (curve == "exponential")
-            a = std::pow(a, 2.0);
-
-        alpha[i] = a;
-    }
-    return alpha;
-}

--- a/src/cpp_audio/Common.h
+++ b/src/cpp_audio/Common.h
@@ -53,8 +53,3 @@ std::vector<double> trapezoidEnvelopeVectorized(const std::vector<double>& tInCy
 std::vector<double> applyFilters(const std::vector<double>& signalSegment,
                                  double fs);
 
-std::vector<double> calculateTransitionAlpha(double totalDuration,
-                                             double sampleRate,
-                                             double initialOffset = 0.0,
-                                             double postOffset = 0.0,
-                                             const std::string& curve = "linear");


### PR DESCRIPTION
## Summary
- remove duplicate calculateTransitionAlpha from Common
- keep single implementation in AudioUtils

## Testing
- `cmake --preset=default` *(fails: JUCE directory missing)*
- `cmake --build --preset=default` *(fails: build directory missing)*

------
https://chatgpt.com/codex/tasks/task_e_685ea8aa7420832d8a51fec2f3597694