### PR TITLE
Async preview generation in StepPreviewer

### DIFF
--- a/src/cpp_audio/StepPreviewer.h
+++ b/src/cpp_audio/StepPreviewer.h
@@ -2,11 +2,16 @@
 #include "Track.h"
 #include "BufferAudioSource.h"
 #include <juce_audio_utils/juce_audio_utils.h>
+#include <juce_core/juce_core.h>
+#include <atomic>
+
+class StepPreviewJob;
 
 class StepPreviewer
 {
 public:
     explicit StepPreviewer(juce::AudioDeviceManager& dm);
+    ~StepPreviewer();
 
     bool loadStep(const Step& step, const GlobalSettings& settings, double previewDuration);
 
@@ -18,8 +23,11 @@ public:
     double getPosition() const;
     double getLength() const;
     bool isPlaying() const;
+    bool isReady() const;
 
 private:
+    void cancelJob();
+    friend class StepPreviewJob;
     juce::AudioBuffer<float> generateAudio(const Step& step, const GlobalSettings& settings, double previewDuration);
 
     juce::AudioDeviceManager& deviceManager;
@@ -29,5 +37,9 @@ private:
     double sampleRate = 44100.0;
     double lengthSeconds = 0.0;
     bool playing = false;
+    std::atomic<bool> ready { false };
+    juce::ThreadPool pool { 1 };
+    std::unique_ptr<juce::ThreadPoolJob> job;
+    juce::CriticalSection lock;
 };
 

--- a/src/cpp_audio/ui/StepPreviewComponent.h
+++ b/src/cpp_audio/ui/StepPreviewComponent.h
@@ -29,5 +29,6 @@ private:
     juce::Label timeLabel;
     juce::Label stepLabel;
     juce::String loadedStepName;
+    bool stepReady { false };
 };
 


### PR DESCRIPTION
## Summary
- generate step previews on a background thread using `juce::ThreadPoolJob`
- expose `isReady()` state for UI polling
- update `StepPreviewComponent` to handle asynchronous preview loading

## Testing
- `echo 'No tests to run'`

------
https://chatgpt.com/codex/tasks/task_e_685ea8c83b38832dbbea8ebe3018aed7