### PR TITLE
Add track saving/loading to cpp audio GUI

### DIFF
--- a/src/cpp_audio/VarUtils.h
+++ b/src/cpp_audio/VarUtils.h
@@ -14,3 +14,22 @@ inline juce::var withDefault(const juce::var& value, const juce::var& defaultVal
 {
     return value.isVoid() ? defaultValue : value;
 }
+
+inline juce::var namedValueSetToVar(const juce::NamedValueSet& set)
+{
+    auto* obj = new juce::DynamicObject();
+    for (const auto& p : set)
+        obj->setProperty(p.name, p.value);
+    return juce::var(obj);
+}
+
+inline juce::NamedValueSet varToNamedValueSet(const juce::var& v)
+{
+    juce::NamedValueSet set;
+    if (auto* obj = v.getDynamicObject())
+    {
+        for (const auto& p : obj->getProperties())
+            set.set(p.name, p.value);
+    }
+    return set;
+}

--- a/src/cpp_audio/ui/StepListPanel.h
+++ b/src/cpp_audio/ui/StepListPanel.h
@@ -1,7 +1,9 @@
 #pragma once
 #include <functional>
 #include <juce_gui_basics/juce_gui_basics.h>
+#include <vector>
 #include "StepConfigPanel.h"
+#include "../Track.h"
 
 class StepListPanel : public juce::Component,
                       private juce::ListBoxModel,
@@ -32,6 +34,10 @@ public:
   // Access steps and selection
   const juce::Array<StepData> &getSteps() const { return steps; }
   int getSelectedIndex() const { return stepList.getSelectedRow(); }
+
+  void setSteps(const std::vector<Step> &newSteps);
+  std::vector<Step> toTrackSteps() const;
+  void clearSteps();
 
   std::function<void(int)> onStepSelected;
 


### PR DESCRIPTION
## Summary
- add helper conversions between juce::NamedValueSet and juce::var
- expose functions on StepListPanel to set/get steps using Track data
- implement New/Open/Save menu actions in main.cpp
- connect StepListPanel and GlobalSettingsComponent when loading or saving tracks

## Testing
- `cmake --preset=default` *(fails: JUCE directory missing)*

------
https://chatgpt.com/codex/tasks/task_e_685eaa76a388832dbab700c49ec445ca