### PR TITLE
Fix ambiguous setSteps overload

### DIFF
--- a/src/cpp_audio/main.cpp
+++ b/src/cpp_audio/main.cpp
@@ -294,7 +294,7 @@ private:
         gs.noiseFile = "";
         gs.noiseAmp = 0.0;
         settings.setSettings(gs);
-        stepList.setSteps({});
+        stepList.clearSteps();
         preview.reset();
         if (auto* w = findParentComponentOfClass<juce::DocumentWindow>())
             w->setName("DIY AV Audio - New File");

--- a/src/cpp_audio/ui/StepListPanel.cpp
+++ b/src/cpp_audio/ui/StepListPanel.cpp
@@ -336,6 +336,16 @@ void StepListPanel::openStepConfig() {
 }
 
 
+void StepListPanel::setSteps(const juce::Array<StepData>& newSteps) {
+  steps = newSteps;
+  stepList.updateContent();
+  stepList.repaint();
+  if (!steps.isEmpty())
+    stepList.selectRow(0);
+  pushHistory();
+  updateDuration();
+}
+
 void StepListPanel::setSteps(const std::vector<Step> &newSteps) {
   steps.clear();
   for (const auto &s : newSteps) {


### PR DESCRIPTION
## Summary
- add implementation for `setSteps` that takes `juce::Array<StepListPanel::StepData>`
- clear the step list with `clearSteps()` when creating a new track

## Testing
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release` *(fails: JUCE not found)*

------
https://chatgpt.com/codex/tasks/task_e_685edde3ced0832da94768e46e67896d