### PR TITLE
Fix per-pixel transparency assertion in dialogs

### DIFF
--- a/src/cpp_audio/main.cpp
+++ b/src/cpp_audio/main.cpp
@@ -24,6 +24,7 @@ public:
   MainComponent()
       : settingsBox("Global Settings"), toolsBox("Tools"),
         previewBox("Step Preview") {
+    setOpaque(true);
     deviceManager.initialise(0, 2, nullptr, true);
     {
       auto ptr = std::make_unique<GlobalSettingsComponent>(deviceManager);

--- a/src/cpp_audio/ui/FrequencyTesterDialog.cpp
+++ b/src/cpp_audio/ui/FrequencyTesterDialog.cpp
@@ -86,6 +86,7 @@ public:
     FrequencyTesterDialog (AudioDeviceManager& dm, Preferences* prefsIn = nullptr)
         : deviceManager (dm)
     {
+        setOpaque(true);
         if (prefsIn)
             prefs = *prefsIn;
 

--- a/src/cpp_audio/ui/NoiseGeneratorDialog.cpp
+++ b/src/cpp_audio/ui/NoiseGeneratorDialog.cpp
@@ -160,6 +160,7 @@ static AudioBuffer<float> generateNoiseBuffer(const NoiseParams &p) {
 // NoiseGeneratorDialog Implementation
 //==============================================================================
 NoiseGeneratorDialog::NoiseGeneratorDialog() {
+  setOpaque(true);
   fileEdit.setText("swept_notch_noise.wav");
   addAndMakeVisible(&fileEdit);
   addAndMakeVisible(&fileBrowse);

--- a/src/cpp_audio/ui/OverlayClipDialog.cpp
+++ b/src/cpp_audio/ui/OverlayClipDialog.cpp
@@ -51,6 +51,7 @@ struct OverlayClipDialogWindow  : public juce::Component,
     OverlayClipDialogWindow(bool ampInDb = false, const ClipData* existing = nullptr)
         : amplitudeInDb(ampInDb)
     {
+        setOpaque(true);
         setSize(400, 260);
         addAndMakeVisible(&fileLabel);
         addAndMakeVisible(&fileEdit);

--- a/src/cpp_audio/ui/OverlayClipPanel.cpp
+++ b/src/cpp_audio/ui/OverlayClipPanel.cpp
@@ -4,6 +4,7 @@
 
 OverlayClipPanel::OverlayClipPanel()
 {
+    setOpaque(true);
     addAndMakeVisible(&clipList);
     clipList.setModel(this);
 

--- a/src/cpp_audio/ui/PreferencesDialog.cpp
+++ b/src/cpp_audio/ui/PreferencesDialog.cpp
@@ -31,6 +31,7 @@ public:
     explicit PreferencesDialog (const Preferences& prefsIn)
         : prefs (prefsIn), ampMode (prefsIn.amplitudeDisplayMode)
     {
+        setOpaque(true);
         setSize (420, 360);
 
         addAndMakeVisible (&fontFamilyLabel);


### PR DESCRIPTION
## Summary
- mark window content components as opaque so they can use native title bars

## Testing
- `cmake -S . -B build -D CMAKE_BUILD_TYPE=Release` *(fails: JUCE directory missing)*

------
https://chatgpt.com/codex/tasks/task_e_68604f1cadb4832d9af5fe53b23f9834