### PR TITLE
Fix JUCE window assertion

### DIFF
--- a/src/cpp_audio/main.cpp
+++ b/src/cpp_audio/main.cpp
@@ -399,6 +399,7 @@ public:
                 juce::ResizableWindow::backgroundColourId),
             juce::DocumentWindow::allButtons) {
     setUsingNativeTitleBar(true);
+    setOpaque(true);
     setResizable(true, true);
 
     mainComponent = new MainComponent();

--- a/src/cpp_audio/ui/DefaultVoiceDialog.cpp
+++ b/src/cpp_audio/ui/DefaultVoiceDialog.cpp
@@ -12,6 +12,7 @@ DefaultVoiceDialog::DefaultVoiceDialog(Preferences& prefs)
       preferences(prefs)
 {
     setUsingNativeTitleBar(true);
+    setOpaque(true);
     setResizable(true, false);
 
     addAndMakeVisible(&synthLabel);

--- a/src/cpp_audio/ui/VoiceEditorDialog.cpp
+++ b/src/cpp_audio/ui/VoiceEditorDialog.cpp
@@ -143,6 +143,7 @@ VoiceEditorDialog::VoiceEditorDialog(
                               : std::vector<std::vector<VoiceData>>{}) {
   hasReferences = refSteps && !refSteps->empty();
   setUsingNativeTitleBar(true);
+  setOpaque(true);
   setResizable(true, false);
 
   addAndMakeVisible(&funcLabel);


### PR DESCRIPTION
## Summary
- ensure all JUCE windows are created opaque

## Testing
- `cmake --preset=default` *(fails: JUCE directory missing)*

------
https://chatgpt.com/codex/tasks/task_e_686042bcde0c832d84e0dc00fbb81c17