### PR TITLE
Fix window opacity for SubliminalDialog

### DIFF
--- a/src/cpp_audio/ui/SubliminalDialog.cpp
+++ b/src/cpp_audio/ui/SubliminalDialog.cpp
@@ -26,6 +26,7 @@ inline double dbToAmplitude(double db)
 SubliminalDialog::SubliminalDialog(bool ampInDb)
     : amplitudeInDb(ampInDb)
 {
+    setOpaque(true);
     setSize(400, 160);
 
     addAndMakeVisible(&fileLabel);


### PR DESCRIPTION
## Summary
- ensure `SubliminalDialog` sets its component to opaque so JUCE does not trigger a native titlebar transparency assertion

## Testing
- `cmake --preset=default` *(fails: JUCE subdirectory missing)*
- `cmake --build --preset=default` *(fails: build.ninja not found)*

------
https://chatgpt.com/codex/tasks/task_e_686079ca1474832dbf2d647d273901c0