### PR TITLE
Fix order of native title bar call to avoid transparency assertion

### DIFF
--- a/src/cpp_audio/main.cpp
+++ b/src/cpp_audio/main.cpp
@@ -399,13 +399,13 @@ public:
             juce::Desktop::getInstance().getDefaultLookAndFeel().findColour(
                 juce::ResizableWindow::backgroundColourId),
             juce::DocumentWindow::allButtons) {
-    setUsingNativeTitleBar(true);
     setOpaque(true);
     setResizable(true, true);
 
     mainComponent = new MainComponent();
     setContentOwned(mainComponent, true);
     setMenuBar(mainComponent);
+    setUsingNativeTitleBar(true);
 
     centreWithSize(getWidth(), getHeight());
     setVisible(true);

--- a/src/cpp_audio/ui/DefaultVoiceDialog.cpp
+++ b/src/cpp_audio/ui/DefaultVoiceDialog.cpp
@@ -11,8 +11,8 @@ DefaultVoiceDialog::DefaultVoiceDialog(Preferences& prefs)
     : DialogWindow("Configure Default Voice", Colours::lightgrey, true),
       preferences(prefs)
 {
-    setUsingNativeTitleBar(true);
     setOpaque(true);
+    setUsingNativeTitleBar(true);
     setResizable(true, false);
 
     addAndMakeVisible(&synthLabel);

--- a/src/cpp_audio/ui/VoiceEditorDialog.cpp
+++ b/src/cpp_audio/ui/VoiceEditorDialog.cpp
@@ -142,8 +142,8 @@ VoiceEditorDialog::VoiceEditorDialog(
       referenceSteps(refSteps ? *refSteps
                               : std::vector<std::vector<VoiceData>>{}) {
   hasReferences = refSteps && !refSteps->empty();
-  setUsingNativeTitleBar(true);
   setOpaque(true);
+  setUsingNativeTitleBar(true);
   setResizable(true, false);
 
   addAndMakeVisible(&funcLabel);


### PR DESCRIPTION
## Summary
- ensure `setOpaque(true)` is called before enabling native title bar
- move `setUsingNativeTitleBar(true)` after content component setup in `MainWindow`
- adjust ordering of `setUsingNativeTitleBar` in dialogs

## Testing
- `cmake ..` *(fails: missing JUCE directory)*

------
https://chatgpt.com/codex/tasks/task_e_68607cfe1170832da1aaad57a2efe93d