### PR TITLE
Fix use-after-free in StepConfigPanel

### DIFF
--- a/src/cpp_audio/main.cpp
+++ b/src/cpp_audio/main.cpp
@@ -15,6 +15,7 @@
 #include "ui/ToolsComponent.h"
 #include <fstream>
 #include <vector>
+#include <memory>
 
 // Global application preferences used across components
 static Preferences prefs;
@@ -48,8 +49,8 @@ public:
 
     {
       auto ptr = std::make_unique<StepConfigPanel>();
-      stepConfig = ptr.get();
-      addAndMakeVisible(stepConfig);
+      stepConfig = std::move(ptr);
+      addAndMakeVisible(stepConfig.get());
     }
 
     addAndMakeVisible(stepList);
@@ -227,7 +228,7 @@ private:
   GlobalSettingsComponent *settings = nullptr;
   ToolsComponent *tools = nullptr;
   StepPreviewComponent *preview = nullptr;
-  StepConfigPanel *stepConfig = nullptr;
+  std::unique_ptr<StepConfigPanel> stepConfig;
   StepListPanel stepList;
 
   std::vector<OverlayClipPanel::ClipData> clips;


### PR DESCRIPTION
## Summary
- ensure StepConfigPanel is owned by MainComponent
- include `<memory>` for unique_ptr

## Testing
- `cmake --preset=default` *(fails: JUCE directory missing)*

------
https://chatgpt.com/codex/tasks/task_e_68616464d930832d8ea0144a3b49d72a