### PR TITLE
Implement missing paint methods

### DIFF
--- a/src/cpp_audio/main.cpp
+++ b/src/cpp_audio/main.cpp
@@ -97,6 +97,11 @@ public:
 
   ~MainComponent() override { deviceManager.closeAudioDevice(); }
 
+  void paint(juce::Graphics &g) override {
+    g.fillAll(getLookAndFeel().findColour(
+        juce::ResizableWindow::backgroundColourId));
+  }
+
   void resized() override {
     auto area = getLocalBounds().reduced(8);
 
@@ -417,6 +422,11 @@ public:
   }
 
   ~MainWindow() override { setMenuBar(nullptr); }
+
+  void paint(juce::Graphics &g) override {
+    g.fillAll(getLookAndFeel().findColour(
+        juce::ResizableWindow::backgroundColourId));
+  }
 
 private:
   MainComponent *mainComponent;

--- a/src/cpp_audio/ui/DefaultVoiceDialog.cpp
+++ b/src/cpp_audio/ui/DefaultVoiceDialog.cpp
@@ -63,6 +63,12 @@ DefaultVoiceDialog::~DefaultVoiceDialog()
     cancelButton.removeListener(this);
 }
 
+void DefaultVoiceDialog::paint(juce::Graphics& g)
+{
+    g.fillAll(getLookAndFeel().findColour(
+        juce::ResizableWindow::backgroundColourId));
+}
+
 void DefaultVoiceDialog::closeButtonPressed()
 {
     setVisible(false);

--- a/src/cpp_audio/ui/DefaultVoiceDialog.h
+++ b/src/cpp_audio/ui/DefaultVoiceDialog.h
@@ -11,6 +11,8 @@ public:
     explicit DefaultVoiceDialog(Preferences& prefs);
     ~DefaultVoiceDialog() override;
 
+    void paint(juce::Graphics& g) override;
+
     juce::var getDefaultVoice() const;
 
     void closeButtonPressed() override;

--- a/src/cpp_audio/ui/FrequencyTesterDialog.cpp
+++ b/src/cpp_audio/ui/FrequencyTesterDialog.cpp
@@ -140,6 +140,12 @@ public:
         stopPlayback();
     }
 
+    void paint(juce::Graphics& g) override
+    {
+        g.fillAll(getLookAndFeel().findColour(
+            juce::ResizableWindow::backgroundColourId));
+    }
+
     void resized() override
     {
         int y = 10;

--- a/src/cpp_audio/ui/NoiseGeneratorDialog.cpp
+++ b/src/cpp_audio/ui/NoiseGeneratorDialog.cpp
@@ -276,6 +276,11 @@ NoiseGeneratorDialog::~NoiseGeneratorDialog() {
   deviceManager.closeAudioDevice();
 }
 
+void NoiseGeneratorDialog::paint(juce::Graphics &g) {
+  g.fillAll(getLookAndFeel().findColour(
+      juce::ResizableWindow::backgroundColourId));
+}
+
 void NoiseGeneratorDialog::resized() {
   int x = 10, y = 10, w = getWidth() - 20, h = 24;
   fileEdit.setBounds(x, y, w - 80, h);

--- a/src/cpp_audio/ui/NoiseGeneratorDialog.h
+++ b/src/cpp_audio/ui/NoiseGeneratorDialog.h
@@ -15,6 +15,8 @@ public:
   NoiseGeneratorDialog();
   ~NoiseGeneratorDialog() override;
 
+  void paint(juce::Graphics &g) override;
+
   void resized() override;
 
 private:

--- a/src/cpp_audio/ui/OverlayClipDialog.cpp
+++ b/src/cpp_audio/ui/OverlayClipDialog.cpp
@@ -125,6 +125,12 @@ struct OverlayClipDialogWindow  : public juce::Component,
     bool wasAccepted() const { return accepted; }
     ClipData getClipData() const { return data; }
 
+    void paint(juce::Graphics& g) override
+    {
+        g.fillAll(getLookAndFeel().findColour(
+            juce::ResizableWindow::backgroundColourId));
+    }
+
     void resized() override
     {
         auto area = getLocalBounds().reduced(10);

--- a/src/cpp_audio/ui/OverlayClipPanel.cpp
+++ b/src/cpp_audio/ui/OverlayClipPanel.cpp
@@ -31,6 +31,12 @@ int OverlayClipPanel::getNumRows()
     return static_cast<int>(clips.size());
 }
 
+void OverlayClipPanel::paint(juce::Graphics& g)
+{
+    g.fillAll(getLookAndFeel().findColour(
+        juce::ResizableWindow::backgroundColourId));
+}
+
 void OverlayClipPanel::paintListBoxItem(int row, juce::Graphics& g, int width, int height, bool rowSel)
 {
     if (rowSel)

--- a/src/cpp_audio/ui/OverlayClipPanel.h
+++ b/src/cpp_audio/ui/OverlayClipPanel.h
@@ -18,6 +18,7 @@ public:
     using ClipData = OverlayClipDialog::ClipData;
 
     int getNumRows() override;
+    void paint(juce::Graphics& g) override;
     void paintListBoxItem(int row, juce::Graphics& g, int width, int height, bool rowIsSelected) override;
     void resized() override;
 

--- a/src/cpp_audio/ui/PreferencesDialog.cpp
+++ b/src/cpp_audio/ui/PreferencesDialog.cpp
@@ -170,6 +170,12 @@ public:
         return p;
     }
 
+    void paint (juce::Graphics& g) override
+    {
+        g.fillAll (getLookAndFeel().findColour (
+            juce::ResizableWindow::backgroundColourId));
+    }
+
     void resized() override
     {
         auto area = getLocalBounds().reduced (10);

--- a/src/cpp_audio/ui/SubliminalDialog.cpp
+++ b/src/cpp_audio/ui/SubliminalDialog.cpp
@@ -86,6 +86,12 @@ Voice SubliminalDialog::getVoice() const
     return voice;
 }
 
+void SubliminalDialog::paint(juce::Graphics& g)
+{
+    g.fillAll(getLookAndFeel().findColour(
+        juce::ResizableWindow::backgroundColourId));
+}
+
 void SubliminalDialog::resized()
 {
     auto area = getLocalBounds().reduced(10);

--- a/src/cpp_audio/ui/SubliminalDialog.h
+++ b/src/cpp_audio/ui/SubliminalDialog.h
@@ -10,6 +10,8 @@ struct SubliminalDialog : public juce::Component,
     bool wasAccepted() const;
     Voice getVoice() const;
 
+    void paint(juce::Graphics& g) override;
+
     void resized() override;
 
 private:

--- a/src/cpp_audio/ui/VoiceEditorDialog.cpp
+++ b/src/cpp_audio/ui/VoiceEditorDialog.cpp
@@ -216,6 +216,11 @@ VoiceEditorDialog::~VoiceEditorDialog() {
   cancelButton.removeListener(this);
 }
 
+void VoiceEditorDialog::paint(juce::Graphics &g) {
+  g.fillAll(getLookAndFeel().findColour(
+      juce::ResizableWindow::backgroundColourId));
+}
+
 bool VoiceEditorDialog::wasAccepted() const { return accepted; }
 
 VoiceEditorDialog::VoiceData VoiceEditorDialog::getVoiceData() const {

--- a/src/cpp_audio/ui/VoiceEditorDialog.h
+++ b/src/cpp_audio/ui/VoiceEditorDialog.h
@@ -44,6 +44,8 @@ public:
       const std::vector<std::vector<VoiceData>> *refSteps = nullptr);
   ~VoiceEditorDialog() override;
 
+  void paint(juce::Graphics &g) override;
+
   bool wasAccepted() const;
   VoiceData getVoiceData() const;
 


### PR DESCRIPTION
## Summary
- ensure opaque components fill their backgrounds
- expose new paint overrides in related headers

## Testing
- `cmake -S . -B build` *(fails: add_subdirectory given source `src/cpp_audio/JUCE` which is not an existing directory)*

------
https://chatgpt.com/codex/tasks/task_e_68616820d3ac832d9ecc6aee659bcbff