### PR TITLE
Implement Rust realtime audio backend skeleton

### DIFF
--- a/src/audio/REALTIME_BACKEND_PLAN.md
+++ b/src/audio/REALTIME_BACKEND_PLAN.md
@@ -1,0 +1,18 @@
+# Rust Real-Time Audio Backend Plan
+
+This document tracks progress on implementing a real-time audio backend in Rust. The goal is to replicate features of `sound_creator.py` for low‑latency playback.
+
+## Implemented
+- Created new Cargo crate `realtime_audio_rs` with modules for `models`, `synths` and `engine`.
+- Added basic data structures (`Track`, `Step`, `Voice`, `GlobalSettings`) using `serde` for JSON loading.
+- Implemented a simple `binaural_beat` generator.
+- Added `RealtimeEngine` that loads a track and plays each step using `rodio`.
+- Provided a command line binary that accepts a track JSON file and plays it.
+
+## TODO
+- Support additional synth functions from Python reference (`isochronic_tone`, etc.).
+- Implement parameter transitions and crossfade logic.
+- Add safety limiter and normalization stages.
+- Expose a web API (e.g., via WebSocket) for remote control.
+- Unit tests comparing generated buffers with Python version.
+- Documentation updates and build instructions.

--- a/src/audio/realtime_backend_rs/.gitignore
+++ b/src/audio/realtime_backend_rs/.gitignore
@@ -1,0 +1,2 @@
+target/
+Cargo.lock

--- a/src/audio/realtime_backend_rs/Cargo.toml
+++ b/src/audio/realtime_backend_rs/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "realtime_audio_rs"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+rodio = "0.17"
+anyhow = "1.0"
+cpal = "0.15"

--- a/src/audio/realtime_backend_rs/src/engine.rs
+++ b/src/audio/realtime_backend_rs/src/engine.rs
@@ -1,0 +1,58 @@
+use crate::models::Track;
+use crate::synths::binaural_beat;
+use rodio::{OutputStream, Sink};
+
+pub struct RealtimeSynthContext {
+    pub sample_rate: u32,
+    pub buffer_size: usize,
+}
+
+impl Default for RealtimeSynthContext {
+    fn default() -> Self {
+        Self { sample_rate: 44100, buffer_size: 512 }
+    }
+}
+
+pub struct RealtimeEngine {
+    context: RealtimeSynthContext,
+    track: Option<Track>,
+}
+
+impl RealtimeEngine {
+    pub fn new(context: RealtimeSynthContext) -> Self {
+        Self { context, track: None }
+    }
+
+    pub fn load_track(&mut self, track: Track) {
+        self.track = Some(track);
+    }
+
+    pub fn play(&self) -> anyhow::Result<()> {
+        let track = self.track.as_ref().ok_or_else(|| anyhow::anyhow!("no track loaded"))?;
+        let (_stream, stream_handle) = OutputStream::try_default()?;
+        let sink = Sink::try_new(&stream_handle)?;
+
+        for step in &track.steps {
+            let num_samples = (step.duration * self.context.sample_rate as f32) as usize;
+            let mut left = vec![0.0f32; num_samples];
+            let mut right = vec![0.0f32; num_samples];
+            for voice in &step.voices {
+                match voice.synth_function_name.as_str() {
+                    "binaural_beat" => {
+                        if let (Some(base), Some(beat)) = (
+                            voice.params.get("baseFreq").and_then(|v| v.as_f64()),
+                            voice.params.get("beatFreq").and_then(|v| v.as_f64()),
+                        ) {
+                            binaural_beat(&mut left, &mut right, base as f32, beat as f32, self.context.sample_rate);
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            let samples: Vec<f32> = left.iter().zip(right.iter()).flat_map(|(&l, &r)| [l, r]).collect();
+            sink.append(rodio::buffer::SamplesBuffer::new(2, self.context.sample_rate, samples));
+        }
+        sink.sleep_until_end();
+        Ok(())
+    }
+}

--- a/src/audio/realtime_backend_rs/src/lib.rs
+++ b/src/audio/realtime_backend_rs/src/lib.rs
@@ -1,0 +1,6 @@
+pub mod models;
+pub mod synths;
+pub mod engine;
+
+pub use crate::models::*;
+pub use crate::engine::{RealtimeEngine, RealtimeSynthContext};

--- a/src/audio/realtime_backend_rs/src/main.rs
+++ b/src/audio/realtime_backend_rs/src/main.rs
@@ -1,0 +1,16 @@
+use realtime_audio_rs::{RealtimeEngine, RealtimeSynthContext, Track};
+use std::fs;
+
+fn main() -> anyhow::Result<()> {
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() < 2 {
+        println!("Usage: realtime_audio_rs <track.json>");
+        return Ok(());
+    }
+    let data = fs::read_to_string(&args[1])?;
+    let track: Track = serde_json::from_str(&data)?;
+    let mut engine = RealtimeEngine::new(RealtimeSynthContext::default());
+    engine.load_track(track);
+    engine.play()?;
+    Ok(())
+}

--- a/src/audio/realtime_backend_rs/src/models.rs
+++ b/src/audio/realtime_backend_rs/src/models.rs
@@ -1,0 +1,45 @@
+use serde::{Serialize, Deserialize};
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Voice {
+    pub synth_function_name: String,
+    #[serde(default)]
+    pub is_transition: bool,
+    #[serde(default)]
+    pub params: serde_json::Value,
+    #[serde(default)]
+    pub description: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Step {
+    pub duration: f32,
+    #[serde(default)]
+    pub description: String,
+    #[serde(default)]
+    pub voices: Vec<Voice>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, Default)]
+pub struct GlobalSettings {
+    #[serde(default = "default_sample_rate")]
+    pub sample_rate: u32,
+    #[serde(default = "default_crossfade_duration")]
+    pub crossfade_duration: f32,
+    #[serde(default = "default_crossfade_curve")]
+    pub crossfade_curve: String,
+    #[serde(default)]
+    pub output_filename: Option<String>,
+}
+
+fn default_sample_rate() -> u32 { 44100 }
+fn default_crossfade_duration() -> f32 { 1.0 }
+fn default_crossfade_curve() -> String { "linear".into() }
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Track {
+    #[serde(default)]
+    pub global_settings: GlobalSettings,
+    #[serde(default)]
+    pub steps: Vec<Step>,
+}

--- a/src/audio/realtime_backend_rs/src/synths.rs
+++ b/src/audio/realtime_backend_rs/src/synths.rs
@@ -1,0 +1,10 @@
+use std::f32::consts::PI;
+
+pub fn binaural_beat(left: &mut [f32], right: &mut [f32], base_freq: f32, beat_freq: f32, sample_rate: u32) {
+    let sr = sample_rate as f32;
+    for i in 0..left.len() {
+        let t = i as f32 / sr;
+        left[i] = (2.0 * PI * (base_freq - beat_freq / 2.0) * t).sin();
+        right[i] = (2.0 * PI * (base_freq + beat_freq / 2.0) * t).sin();
+    }
+}


### PR DESCRIPTION
## Summary
- add Rust crate `realtime_audio_rs` with data models, synth module, and realtime engine
- implement a basic binaural beat generator and playback via rodio
- provide CLI example and documentation of work in `REALTIME_BACKEND_PLAN.md`

## Testing
- `cargo build --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6861e34427c8832d948697bafefeff72